### PR TITLE
Use two column layout on phones

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -134,7 +134,7 @@ nav a.active {
 
 @media (max-width: 600px) {
   .gallery-grid {
-    column-count: 1;
+    column-count: 2;
   }
 
   .site-logo img {


### PR DESCRIPTION
## Summary
- keep 2-column masonry layout for small screens

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_688aeaa7712c832a87061afcd86a5e57