### PR TITLE
Add fade-in lazyload effect

### DIFF
--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -7,9 +7,16 @@ document.addEventListener("DOMContentLoaded", () => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           const el = entry.target;
-          el.src = el.dataset.src;
+          const onLoad = () => {
+            el.parentElement.classList.add("loaded");
+          };
           if (el.tagName === "VIDEO") {
+            el.src = el.dataset.src;
             el.load();
+            el.addEventListener("loadeddata", onLoad, { once: true });
+          } else {
+            el.src = el.dataset.src;
+            el.addEventListener("load", onLoad, { once: true });
           }
           observer.unobserve(el);
         }

--- a/css/styles.css
+++ b/css/styles.css
@@ -114,6 +114,7 @@ nav a.active {
   margin-bottom: 1rem;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
   break-inside: avoid;
+  aspect-ratio: 1/1;
 }
 
 .gallery-item img,
@@ -123,6 +124,13 @@ nav a.active {
   display: block;
   border-radius: 8px;
   object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.gallery-item.loaded img,
+.gallery-item.loaded video {
+  opacity: 1;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- add IntersectionObserver lazyload callback that fades items in when loaded
- fade in images and videos with CSS transition and default square ratio

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d427f2d48832aa341626998b9bb5f