### PR TITLE
Add fade-in lazy load for gallery items

### DIFF
--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -1,21 +1,34 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const lazyElements = document.querySelectorAll(
-    "img[data-src],video[data-src]",
-  );
+  const lazyElements = document.querySelectorAll("img[data-src],video[data-src]");
+
   const observer = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const el = entry.target;
+        if (!entry.isIntersecting) return;
+
+        const el = entry.target;
+        const parent = el.closest(".gallery-item");
+
+        const onLoad = () => {
+          parent?.classList.add("loaded");
+          el.removeEventListener("load", onLoad);
+          el.removeEventListener("loadeddata", onLoad);
+        };
+
+        if (el.tagName === "IMG") {
+          el.addEventListener("load", onLoad, { once: true });
           el.src = el.dataset.src;
-          if (el.tagName === "VIDEO") {
-            el.load();
-          }
-          observer.unobserve(el);
+        } else if (el.tagName === "VIDEO") {
+          el.addEventListener("loadeddata", onLoad, { once: true });
+          el.src = el.dataset.src;
+          el.load();
         }
+
+        observer.unobserve(el);
       });
     },
-    { rootMargin: "200px 0px" },
+    { rootMargin: "200px 0px" }
   );
+
   lazyElements.forEach((el) => observer.observe(el));
 });

--- a/css/styles.css
+++ b/css/styles.css
@@ -122,7 +122,14 @@ nav a.active {
   height: auto;
   display: block;
   border-radius: 8px;
-  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  object-fit: contain;
+}
+
+.gallery-item.loaded img,
+.gallery-item.loaded video {
+  opacity: 1;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- enhance `lazyload.js` to use `IntersectionObserver` and fade in elements
- set up fade-in transition styles and no-crop media display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d4da69300832aa9eb13c2c6180abe