### PR TITLE
Improve lazy load fade-in

### DIFF
--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -10,9 +10,11 @@ document.addEventListener("DOMContentLoaded", () => {
         const parent = el.closest(".gallery-item");
 
         const onLoad = () => {
-          parent?.classList.add("loaded");
-          el.removeEventListener("load", onLoad);
-          el.removeEventListener("loadeddata", onLoad);
+          setTimeout(() => {
+            parent?.classList.add("loaded");
+            el.removeEventListener("load", onLoad);
+            el.removeEventListener("loadeddata", onLoad);
+          }, 50);
         };
 
         if (el.tagName === "IMG") {

--- a/css/styles.css
+++ b/css/styles.css
@@ -114,6 +114,9 @@ nav a.active {
   margin-bottom: 1rem;
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
   break-inside: avoid;
+  contain: content;
+  opacity: 0;
+  transition: opacity 0.6s ease;
 }
 
 .gallery-item img,
@@ -127,6 +130,7 @@ nav a.active {
   object-fit: contain;
 }
 
+.gallery-item.loaded,
 .gallery-item.loaded img,
 .gallery-item.loaded video {
   opacity: 1;


### PR DESCRIPTION
## Summary
- fade items in smoothly when lazy loaded
- tweak gallery item style to avoid layout reflow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688d5a838ba8832ab8ae2607d3e5da5b