### PR TITLE
Add social metadata and favicon placeholders

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,9 +6,20 @@
   <title>lostless — about</title>
   <meta name="description" content="lostless is an audiovisual artist creating immersive visual experiences using AI and real-time tools.">
   <meta name="author" content="lostless">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="lostless">
+  <meta property="og:title" content="lostless — generative visuals">
+  <meta property="og:description" content="Visuals for live music, film, and installations.">
+  <meta property="og:url" content="https://lostless.live/">
+  <meta property="og:image" content="/assets/social/og-image.jpg">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="lostless — generative visuals">
+  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
+  <meta name="twitter:image" content="/assets/social/og-image.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="/assets/meta/favicon.png">
+  <link rel="icon" href="/assets/favicon/favicon.ico">
 </head>
 <body>
 

--- a/assets/favicon/favicon-16x16.png
+++ b/assets/favicon/favicon-16x16.png
@@ -1,0 +1,1 @@
+Place favicon here

--- a/assets/favicon/favicon-32x32.png
+++ b/assets/favicon/favicon-32x32.png
@@ -1,0 +1,1 @@
+Place favicon here

--- a/assets/favicon/favicon.ico
+++ b/assets/favicon/favicon.ico
@@ -1,0 +1,1 @@
+Place favicon here

--- a/assets/social/og-image.txt
+++ b/assets/social/og-image.txt
@@ -1,0 +1,1 @@
+Place your 1200×630 JPG here

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,9 +6,20 @@
   <title>contact — lostless</title>
   <meta name="description" content="get in touch with lostless for bookings, commissions, or collaborations.">
   <meta name="author" content="lostless">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="lostless">
+  <meta property="og:title" content="lostless — generative visuals">
+  <meta property="og:description" content="Visuals for live music, film, and installations.">
+  <meta property="og:url" content="https://lostless.live/">
+  <meta property="og:image" content="/assets/social/og-image.jpg">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="lostless — generative visuals">
+  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
+  <meta name="twitter:image" content="/assets/social/og-image.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="/assets/meta/favicon.png">
+  <link rel="icon" href="/assets/favicon/favicon.ico">
 </head>
 <body style="background-color: #000;">
 

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -7,9 +7,20 @@
   <title>lostless — highlights</title>
   <meta name="description" content="selected works and showreels by lostless: live performance, touchdesigner, and AI visuals.">
   <meta name="author" content="lostless">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="lostless">
+  <meta property="og:title" content="lostless — generative visuals">
+  <meta property="og:description" content="Visuals for live music, film, and installations.">
+  <meta property="og:url" content="https://lostless.live/">
+  <meta property="og:image" content="/assets/social/og-image.jpg">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="lostless — generative visuals">
+  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
+  <meta name="twitter:image" content="/assets/social/og-image.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="/assets/meta/favicon.png">
+  <link rel="icon" href="/assets/favicon/favicon.ico">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -6,14 +6,20 @@
   <title>lostless — work</title>
   <meta name="description" content="generative visuals for live performance, music videos, and installations using touchdesigner, comfyui, and real-time ai tools.">
   <meta name="author" content="lostless">
-  <meta property="og:title" content="lostless — ai visuals & vj sets">
-  <meta property="og:description" content="generative visuals for live performance, music videos, and installations.">
-  <meta property="og:image" content="https://lostless.live/assets/meta/preview.jpg">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="lostless">
+  <meta property="og:title" content="lostless — generative visuals">
+  <meta property="og:description" content="Visuals for live music, film, and installations.">
+  <meta property="og:url" content="https://lostless.live/">
+  <meta property="og:image" content="/assets/social/og-image.jpg">
+
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://lostless.live/assets/meta/preview.jpg">
+  <meta name="twitter:title" content="lostless — generative visuals">
+  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
+  <meta name="twitter:image" content="/assets/social/og-image.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="/assets/meta/favicon.png">
+  <link rel="icon" href="/assets/favicon/favicon.ico">
 
 </head>
 <body style="background-color: #000;">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata plus favicon link to all site pages
- introduce placeholder directories for social image and favicon assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993c0cacdc832a84720deb44192d10