### PR TITLE
Update social preview image metadata

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -11,12 +11,14 @@
   <meta property="og:title" content="lostless — generative visuals">
   <meta property="og:description" content="Visuals for live music, film, and installations.">
   <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/social/og-image.jpg">
+  <meta property="og:image" content="/assets/meta/preview.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="lostless — generative visuals">
   <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/social/og-image.jpg">
+  <meta name="twitter:image" content="/assets/meta/preview.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/contact/index.html
+++ b/contact/index.html
@@ -11,12 +11,14 @@
   <meta property="og:title" content="lostless — generative visuals">
   <meta property="og:description" content="Visuals for live music, film, and installations.">
   <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/social/og-image.jpg">
+  <meta property="og:image" content="/assets/meta/preview.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="lostless — generative visuals">
   <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/social/og-image.jpg">
+  <meta name="twitter:image" content="/assets/meta/preview.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -12,12 +12,14 @@
   <meta property="og:title" content="lostless — generative visuals">
   <meta property="og:description" content="Visuals for live music, film, and installations.">
   <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/social/og-image.jpg">
+  <meta property="og:image" content="/assets/meta/preview.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="lostless — generative visuals">
   <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/social/og-image.jpg">
+  <meta name="twitter:image" content="/assets/meta/preview.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/index.html
+++ b/index.html
@@ -11,12 +11,14 @@
   <meta property="og:title" content="lostless — generative visuals">
   <meta property="og:description" content="Visuals for live music, film, and installations.">
   <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/social/og-image.jpg">
+  <meta property="og:image" content="/assets/meta/preview.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="lostless — generative visuals">
   <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/social/og-image.jpg">
+  <meta name="twitter:image" content="/assets/meta/preview.jpg">
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">


### PR DESCRIPTION
## Summary
- Reference the shared preview image for Open Graph and Twitter metadata across pages
- Add og:image width and height metadata for proper rendering

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68993ed50c10832aaba7335167985c4d