### PR TITLE
meta: centralize OG/Twitter meta into shared partial

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,19 +6,7 @@
   <title>lostless — about</title>
   <meta name="description" content="lostless is an audiovisual artist creating immersive visual experiences using AI and real-time tools.">
   <meta name="author" content="lostless">
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="lostless">
-  <meta property="og:title" content="lostless — generative visuals">
-  <meta property="og:description" content="Visuals for live music, film, and installations.">
-  <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/meta/preview.jpg">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="lostless — generative visuals">
-  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/meta/preview.jpg">
+  <!--#include virtual="/includes/meta-social.html" -->
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,19 +6,7 @@
   <title>contact — lostless</title>
   <meta name="description" content="get in touch with lostless for bookings, commissions, or collaborations.">
   <meta name="author" content="lostless">
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="lostless">
-  <meta property="og:title" content="lostless — generative visuals">
-  <meta property="og:description" content="Visuals for live music, film, and installations.">
-  <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/meta/preview.jpg">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="lostless — generative visuals">
-  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/meta/preview.jpg">
+  <!--#include virtual="/includes/meta-social.html" -->
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -7,19 +7,7 @@
   <title>lostless — highlights</title>
   <meta name="description" content="selected works and showreels by lostless: live performance, touchdesigner, and AI visuals.">
   <meta name="author" content="lostless">
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="lostless">
-  <meta property="og:title" content="lostless — generative visuals">
-  <meta property="og:description" content="Visuals for live music, film, and installations.">
-  <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/meta/preview.jpg">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="lostless — generative visuals">
-  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/meta/preview.jpg">
+  <!--#include virtual="/includes/meta-social.html" -->
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">

--- a/includes/meta-social.html
+++ b/includes/meta-social.html
@@ -1,0 +1,13 @@
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="lostless">
+<meta property="og:title" content="lostless — generative visuals">
+<meta property="og:description" content="Visuals for live music, film, and installations.">
+<meta property="og:url" content="https://lostless.live/">
+<meta property="og:image" content="/assets/meta/preview.jpg">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="lostless — generative visuals">
+<meta name="twitter:description" content="Visuals for live music, film, and installations.">
+<meta name="twitter:image" content="/assets/meta/preview.jpg">

--- a/index.html
+++ b/index.html
@@ -6,19 +6,7 @@
   <title>lostless — work</title>
   <meta name="description" content="generative visuals for live performance, music videos, and installations using touchdesigner, comfyui, and real-time ai tools.">
   <meta name="author" content="lostless">
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="lostless">
-  <meta property="og:title" content="lostless — generative visuals">
-  <meta property="og:description" content="Visuals for live music, film, and installations.">
-  <meta property="og:url" content="https://lostless.live/">
-  <meta property="og:image" content="/assets/meta/preview.jpg">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="lostless — generative visuals">
-  <meta name="twitter:description" content="Visuals for live music, film, and installations.">
-  <meta name="twitter:image" content="/assets/meta/preview.jpg">
+  <!--#include virtual="/includes/meta-social.html" -->
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">


### PR DESCRIPTION
## Summary
- factor out Open Graph and Twitter meta tags into new `includes/meta-social.html`
- include the shared social meta partial on index, about, contact, and highlights pages

## Testing
- `python3 -m http.server 8000 & curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689940176548832a8ec9a842b25c8fb8