### PR TITLE
Add Plausible analytics and event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ lostless.live
 ```
 
 When the site is deployed with GitHub Pages, GitHub reads this file and configures the deployment so that `lostless.live` resolves to the contents of this repository.
+
+## Analytics
+
+This site uses [Plausible](https://plausible.io/) for privacy-friendly analytics. The service offers a free trial and then requires a paid plan. All events are tracked for the `lostless.live` domain.

--- a/about/index.html
+++ b/about/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">
+  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 
@@ -39,7 +40,7 @@
       <p>i like when things don’t <span style="display:inline-block; transform: rotate(180deg) scaleX(-1);">behave</span> <span style="display:inline-block; transform: rotate(180deg);">behave</span> <span style="display:inline-block;">behave</span></p>
 
 
-    <a href="https://www.instagram.com/lostless.visuals" target="_blank" style="display:inline-flex;align-items:center;gap:8px;text-decoration:none;color:#ff3366;margin-top:1.5rem;font-weight:600;">
+    <a href="https://www.instagram.com/lostless.visuals" target="_blank" onclick="plausible('Instagram Click')" style="display:inline-flex;align-items:center;gap:8px;text-decoration:none;color:#ff3366;margin-top:1.5rem;font-weight:600;">
       <img src="/assets/meta/instagram-icon.svg" alt="Instagram" style="height: 20px; width: 20px;" />
       follow @lostless.visuals
     </a>

--- a/contact/index.html
+++ b/contact/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">
+  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
 </head>
 <body style="background-color: #000;">
 
@@ -30,13 +31,13 @@
   <main class="centered-section">
     <p>inquiries, bookings, commissions:</p>
 
-    <a href="mailto:lostless.visuals@gmail.com" class="contact-link">
+    <a href="mailto:lostless.visuals@gmail.com" class="contact-link" onclick="plausible('Contact Email')">
       lostless.visuals@gmail.com
     </a>
 
     <p style="margin-top: 2rem;">
       or dm on instagram:<br>
-      <a href="https://www.instagram.com/lostless.visuals/" target="_blank" class="ig-link" style="display:inline-flex;align-items:center;gap:6px;text-decoration:none;color:#ff3366;">
+      <a href="https://www.instagram.com/lostless.visuals/" target="_blank" class="ig-link" onclick="plausible('Instagram Click')" style="display:inline-flex;align-items:center;gap:6px;text-decoration:none;color:#ff3366;">
         <img src="/assets/meta/instagram-icon.svg" alt="instagram" style="height: 18px; width: 18px;" />
         @lostless.visuals
       </a>

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">
+  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">
+  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
 
 </head>
 <body style="background-color: #000;">
@@ -360,6 +361,21 @@
   </div>
     </section>
   </main>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('.gallery-item').forEach(item => {
+        item.addEventListener('click', () => {
+          const media = item.querySelector('img, video');
+          if (!media) return;
+          const slug = media.getAttribute('alt') || media.getAttribute('src').split('/').pop().split('.')[0];
+          if (window.plausible) {
+            plausible('Lightbox Open', { props: { item: slug } });
+          }
+        });
+      });
+    });
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Plausible analytics script to every page
- track lightbox, email, and Instagram events with Plausible
- document analytics setup and domain in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68994154d090832ab494ba31960a9083