### PR TITLE
fix: use static gallery order

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,12 +364,6 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', function () {
-      const grid = document.querySelector('.gallery-grid');
-      if (grid) {
-        const items = Array.from(grid.children);
-        items.sort(() => Math.random() - 0.5);
-        items.forEach(item => grid.appendChild(item));
-      }
 
       document.querySelectorAll('.gallery-item').forEach(item => {
         item.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove client-side shuffle so gallery keeps consistent order

## Testing
- `python3 -m http.server 8000 & sleep 1 && kill $!`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899596da678832ab53fef1e03ff5b3a