### PR TITLE
Order work gallery items alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,40 +39,9 @@
     <section class="gallery-grid grid">
   <div class="gallery-item">
     <picture>
-      <source type="image/avif" srcset="/assets/images/image34.avif" />
-      <source type="image/webp" srcset="/assets/images/image34.webp" />
-      <img src="/assets/images/image34.webp" alt="snake-queen" width="607" height="1080" fetchpriority="high" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video7.mp4" autoplay muted loop playsinline width="608" height="1080"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image9.avif" />
-      <source type="image/webp" srcset="/assets/images/image9.webp" />
-      <img src="/assets/images/image9.webp" alt="martial-arts" width="609" height="1080" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image31.avif" />
-      <source type="image/webp" srcset="/assets/images/image31.webp" />
-      <img src="/assets/images/image31.webp" alt="blood-cherry-blossom" width="1080" height="609" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video6.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image37.avif" />
-      <source type="image/webp" srcset="/assets/images/image37.webp" />
-      <img src="/assets/images/image37.webp" alt="cubic" width="609" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video9.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image16.avif" />
-      <source type="image/webp" srcset="/assets/images/image16.webp" />
-      <img src="/assets/images/image16.webp" alt="jellyfish-clouds" width="1080" height="609" loading="lazy" decoding="async" />
+      <source type="image/avif" srcset="/assets/images/image7.avif" />
+      <source type="image/webp" srcset="/assets/images/image7.webp" />
+      <img src="/assets/images/image7.webp" alt="audio-react" width="608" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
   <div class="gallery-item">
@@ -84,198 +53,9 @@
   </div>
   <div class="gallery-item">
     <picture>
-      <source type="image/avif" srcset="/assets/images/image40.avif" />
-      <source type="image/webp" srcset="/assets/images/image40.webp" />
-      <img src="/assets/images/image40.webp" alt="tiger-outline" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image30.avif" />
-      <source type="image/webp" srcset="/assets/images/image30.webp" />
-      <img src="/assets/images/image30.webp" alt="solar" width="1080" height="609" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video16.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video21.mp4" autoplay muted loop playsinline width="610" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video26.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video12.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image8.avif" />
-      <source type="image/webp" srcset="/assets/images/image8.webp" />
-      <img src="/assets/images/image8.webp" alt="explode" width="612" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video19.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image26.avif" />
-      <source type="image/webp" srcset="/assets/images/image26.webp" />
-      <img src="/assets/images/image26.webp" alt="ghost-in-the-shell" width="1080" height="608" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video18.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image19.avif" />
-      <source type="image/webp" srcset="/assets/images/image19.webp" />
-      <img src="/assets/images/image19.webp" alt="spectre" width="1080" height="606" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video24.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image20.avif" />
-      <source type="image/webp" srcset="/assets/images/image20.webp" />
-      <img src="/assets/images/image20.webp" alt="octopus-texture" width="609" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image21.avif" />
-      <source type="image/webp" srcset="/assets/images/image21.webp" />
-      <img src="/assets/images/image21.webp" alt="cyber" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video15.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video10.mp4" autoplay muted loop playsinline width="606" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video32.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video17.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video25.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video2.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video11.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image24.avif" />
-      <source type="image/webp" srcset="/assets/images/image24.webp" />
-      <img src="/assets/images/image24.webp" alt="slime-installation" width="1080" height="608" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image3.avif" />
-      <source type="image/webp" srcset="/assets/images/image3.webp" />
-      <img src="/assets/images/image3.webp" alt="livemusic" width="914" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image17.avif" />
-      <source type="image/webp" srcset="/assets/images/image17.webp" />
-      <img src="/assets/images/image17.webp" alt="jellyfish" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video13.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image23.avif" />
-      <source type="image/webp" srcset="/assets/images/image23.webp" />
-      <img src="/assets/images/image23.webp" alt="lotus" width="1080" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video20.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image25.avif" />
-      <source type="image/webp" srcset="/assets/images/image25.webp" />
-      <img src="/assets/images/image25.webp" alt="tiger" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image6.avif" />
-      <source type="image/webp" srcset="/assets/images/image6.webp" />
-      <img src="/assets/images/image6.webp" alt="skull-art" width="1080" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image7.avif" />
-      <source type="image/webp" srcset="/assets/images/image7.webp" />
-      <img src="/assets/images/image7.webp" alt="audio-react" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video3.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video29.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image10.avif" />
-      <source type="image/webp" srcset="/assets/images/image10.webp" />
-      <img src="/assets/images/image10.webp" alt="landscape" width="609" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video8.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image22.avif" />
-      <source type="image/webp" srcset="/assets/images/image22.webp" />
-      <img src="/assets/images/image22.webp" alt="technicolor" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video23.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video27.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image11.avif" />
-      <source type="image/webp" srcset="/assets/images/image11.webp" />
-      <img src="/assets/images/image11.webp" alt="yellow-devil" width="609" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image1.avif" />
-      <source type="image/webp" srcset="/assets/images/image1.webp" />
-      <img src="/assets/images/image1.webp" alt="vjing" width="1080" height="721" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video30.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image38.avif" />
-      <source type="image/webp" srcset="/assets/images/image38.webp" />
-      <img src="/assets/images/image38.webp" alt="ghost" width="606" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video31.mp4" autoplay muted loop playsinline width="1088" height="1928" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video22.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image27.avif" />
-      <source type="image/webp" srcset="/assets/images/image27.webp" />
-      <img src="/assets/images/image27.webp" alt="liminal-space" width="1080" height="608" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image35.avif" />
-      <source type="image/webp" srcset="/assets/images/image35.webp" />
-      <img src="/assets/images/image35.webp" alt="eye-texture" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video4.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video1.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video5.mp4" autoplay muted loop playsinline width="612" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image13.avif" />
-      <source type="image/webp" srcset="/assets/images/image13.webp" />
-      <img src="/assets/images/image13.webp" alt="shell" width="1080" height="609" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video33.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image2.avif" />
-      <source type="image/webp" srcset="/assets/images/image2.webp" />
-      <img src="/assets/images/image2.webp" alt="live-performance-warehouse" width="1080" height="721" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image39.avif" />
-      <source type="image/webp" srcset="/assets/images/image39.webp" />
-      <img src="/assets/images/image39.webp" alt="snake-green" width="609" height="1080" loading="lazy" decoding="async" />
+      <source type="image/avif" srcset="/assets/images/image31.avif" />
+      <source type="image/webp" srcset="/assets/images/image31.webp" />
+      <img src="/assets/images/image31.webp" alt="blood-cherry-blossom" width="1080" height="609" />
     </picture>
   </div>
   <div class="gallery-item">
@@ -285,29 +65,18 @@
       <img src="/assets/images/image33.webp" alt="bloodrobot" width="1080" height="609" loading="lazy" decoding="async" />
     </picture>
   </div>
-  <div class="gallery-item"><video src="/assets/media/video35.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
   <div class="gallery-item">
     <picture>
-      <source type="image/avif" srcset="/assets/images/image28.avif" />
-      <source type="image/webp" srcset="/assets/images/image28.webp" />
-      <img src="/assets/images/image28.webp" alt="villan" width="609" height="1080" loading="lazy" decoding="async" />
+      <source type="image/avif" srcset="/assets/images/image37.avif" />
+      <source type="image/webp" srcset="/assets/images/image37.webp" />
+      <img src="/assets/images/image37.webp" alt="cubic" width="609" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
-  <div class="gallery-item"><video src="/assets/media/video28.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video34.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
   <div class="gallery-item">
     <picture>
-      <source type="image/avif" srcset="/assets/images/image5.avif" />
-      <source type="image/webp" srcset="/assets/images/image5.webp" />
-      <img src="/assets/images/image5.webp" alt="installation" width="608" height="1080" loading="lazy" decoding="async" />
-    </picture>
-  </div>
-  <div class="gallery-item"><video src="/assets/media/video14.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item">
-    <picture>
-      <source type="image/avif" srcset="/assets/images/image12.avif" />
-      <source type="image/webp" srcset="/assets/images/image12.webp" />
-      <img src="/assets/images/image12.webp" alt="surreal" width="609" height="1080" loading="lazy" decoding="async" />
+      <source type="image/avif" srcset="/assets/images/image21.avif" />
+      <source type="image/webp" srcset="/assets/images/image21.webp" />
+      <img src="/assets/images/image21.webp" alt="cyber" width="608" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
   <div class="gallery-item">
@@ -319,9 +88,114 @@
   </div>
   <div class="gallery-item">
     <picture>
+      <source type="image/avif" srcset="/assets/images/image8.avif" />
+      <source type="image/webp" srcset="/assets/images/image8.webp" />
+      <img src="/assets/images/image8.webp" alt="explode" width="612" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image35.avif" />
+      <source type="image/webp" srcset="/assets/images/image35.webp" />
+      <img src="/assets/images/image35.webp" alt="eye-texture" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image38.avif" />
+      <source type="image/webp" srcset="/assets/images/image38.webp" />
+      <img src="/assets/images/image38.webp" alt="ghost" width="606" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image26.avif" />
+      <source type="image/webp" srcset="/assets/images/image26.webp" />
+      <img src="/assets/images/image26.webp" alt="ghost-in-the-shell" width="1080" height="608" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image5.avif" />
+      <source type="image/webp" srcset="/assets/images/image5.webp" />
+      <img src="/assets/images/image5.webp" alt="installation" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image17.avif" />
+      <source type="image/webp" srcset="/assets/images/image17.webp" />
+      <img src="/assets/images/image17.webp" alt="jellyfish" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image16.avif" />
+      <source type="image/webp" srcset="/assets/images/image16.webp" />
+      <img src="/assets/images/image16.webp" alt="jellyfish-clouds" width="1080" height="609" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
       <source type="image/avif" srcset="/assets/images/image18.avif" />
       <source type="image/webp" srcset="/assets/images/image18.webp" />
       <img src="/assets/images/image18.webp" alt="jungle" width="1080" height="609" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image10.avif" />
+      <source type="image/webp" srcset="/assets/images/image10.webp" />
+      <img src="/assets/images/image10.webp" alt="landscape" width="609" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image27.avif" />
+      <source type="image/webp" srcset="/assets/images/image27.webp" />
+      <img src="/assets/images/image27.webp" alt="liminal-space" width="1080" height="608" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image2.avif" />
+      <source type="image/webp" srcset="/assets/images/image2.webp" />
+      <img src="/assets/images/image2.webp" alt="live-performance-warehouse" width="1080" height="721" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image3.avif" />
+      <source type="image/webp" srcset="/assets/images/image3.webp" />
+      <img src="/assets/images/image3.webp" alt="livemusic" width="914" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image23.avif" />
+      <source type="image/webp" srcset="/assets/images/image23.webp" />
+      <img src="/assets/images/image23.webp" alt="lotus" width="1080" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image9.avif" />
+      <source type="image/webp" srcset="/assets/images/image9.webp" />
+      <img src="/assets/images/image9.webp" alt="martial-arts" width="609" height="1080" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image15.avif" />
+      <source type="image/webp" srcset="/assets/images/image15.webp" />
+      <img src="/assets/images/image15.webp" alt="necrosis" width="609" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image20.avif" />
+      <source type="image/webp" srcset="/assets/images/image20.webp" />
+      <img src="/assets/images/image20.webp" alt="octopus-texture" width="609" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
   <div class="gallery-item">
@@ -340,9 +214,128 @@
   </div>
   <div class="gallery-item">
     <picture>
+      <source type="image/avif" srcset="/assets/images/image13.avif" />
+      <source type="image/webp" srcset="/assets/images/image13.webp" />
+      <img src="/assets/images/image13.webp" alt="shell" width="1080" height="609" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image6.avif" />
+      <source type="image/webp" srcset="/assets/images/image6.webp" />
+      <img src="/assets/images/image6.webp" alt="skull-art" width="1080" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image24.avif" />
+      <source type="image/webp" srcset="/assets/images/image24.webp" />
+      <img src="/assets/images/image24.webp" alt="slime-installation" width="1080" height="608" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image39.avif" />
+      <source type="image/webp" srcset="/assets/images/image39.webp" />
+      <img src="/assets/images/image39.webp" alt="snake-green" width="609" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image34.avif" />
+      <source type="image/webp" srcset="/assets/images/image34.webp" />
+      <img src="/assets/images/image34.webp" alt="snake-queen" width="607" height="1080" fetchpriority="high" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image30.avif" />
+      <source type="image/webp" srcset="/assets/images/image30.webp" />
+      <img src="/assets/images/image30.webp" alt="solar" width="1080" height="609" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image19.avif" />
+      <source type="image/webp" srcset="/assets/images/image19.webp" />
+      <img src="/assets/images/image19.webp" alt="spectre" width="1080" height="606" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
       <source type="image/avif" srcset="/assets/images/image36.avif" />
       <source type="image/webp" srcset="/assets/images/image36.webp" />
       <img src="/assets/images/image36.webp" alt="squares" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image12.avif" />
+      <source type="image/webp" srcset="/assets/images/image12.webp" />
+      <img src="/assets/images/image12.webp" alt="surreal" width="609" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image22.avif" />
+      <source type="image/webp" srcset="/assets/images/image22.webp" />
+      <img src="/assets/images/image22.webp" alt="technicolor" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image25.avif" />
+      <source type="image/webp" srcset="/assets/images/image25.webp" />
+      <img src="/assets/images/image25.webp" alt="tiger" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image40.avif" />
+      <source type="image/webp" srcset="/assets/images/image40.webp" />
+      <img src="/assets/images/image40.webp" alt="tiger-outline" width="608" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+  <div class="gallery-item"><video src="/assets/media/video1.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video10.mp4" autoplay muted loop playsinline width="606" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video11.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video12.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video13.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video14.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video15.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video16.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video17.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video18.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video19.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video2.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video20.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video21.mp4" autoplay muted loop playsinline width="610" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video22.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video23.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video24.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video25.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video26.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video27.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video28.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video29.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video3.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video30.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video31.mp4" autoplay muted loop playsinline width="1088" height="1928" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video32.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video33.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video34.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video35.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video4.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video5.mp4" autoplay muted loop playsinline width="612" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video6.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video7.mp4" autoplay muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video8.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video src="/assets/media/video9.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image28.avif" />
+      <source type="image/webp" srcset="/assets/images/image28.webp" />
+      <img src="/assets/images/image28.webp" alt="villan" width="609" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
   <div class="gallery-item">
@@ -354,12 +347,19 @@
   </div>
   <div class="gallery-item">
     <picture>
-      <source type="image/avif" srcset="/assets/images/image15.avif" />
-      <source type="image/webp" srcset="/assets/images/image15.webp" />
-      <img src="/assets/images/image15.webp" alt="necrosis" width="609" height="1080" loading="lazy" decoding="async" />
+      <source type="image/avif" srcset="/assets/images/image1.avif" />
+      <source type="image/webp" srcset="/assets/images/image1.webp" />
+      <img src="/assets/images/image1.webp" alt="vjing" width="1080" height="721" loading="lazy" decoding="async" />
     </picture>
   </div>
-    </section>
+  <div class="gallery-item">
+    <picture>
+      <source type="image/avif" srcset="/assets/images/image11.avif" />
+      <source type="image/webp" srcset="/assets/images/image11.webp" />
+      <img src="/assets/images/image11.webp" alt="yellow-devil" width="609" height="1080" loading="lazy" decoding="async" />
+    </picture>
+  </div>
+</section>
   </main>
 
   <script>


### PR DESCRIPTION
## Summary
- Sort work page gallery items alphabetically by slug for consistent, non-shuffled display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689963e507ac832a9beb541db1fe30cb