### PR TITLE
Add grid layout to highlights and new video

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -83,6 +83,21 @@ nav a.active {
   margin-bottom: 2rem;
 }
 
+/* Grid layout for highlight videos */
+.highlights-grid {
+  max-width: 1200px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  padding: 4rem 2rem;
+  margin: 0 auto;
+}
+
+.highlights-grid .video-link {
+  margin: 0;
+  max-width: 100%;
+}
+
 /* Big logo on index */
 .logo-big {
   text-align: center;

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -29,22 +29,24 @@
     </nav>
   </header>
 
-  <main class="centered-section">
+  <main class="centered-section highlights-grid">
 
     <div class="video-link">
       <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen></iframe>
     </div>
 
-    <div class="video-row">
-      <div class="video-link">
-        <iframe src="https://www.youtube.com/embed/8xX1yvvVVNE" allowfullscreen></iframe>
-      </div>
-
-      <div class="video-link">
-        <iframe src="https://www.youtube.com/embed/FmUmwU6VAus" allowfullscreen></iframe>
-      </div>
-
+    <div class="video-link">
+      <iframe src="https://www.youtube.com/embed/8xX1yvvVVNE" allowfullscreen></iframe>
     </div>
+
+    <div class="video-link">
+      <iframe src="https://www.youtube.com/embed/FmUmwU6VAus" allowfullscreen></iframe>
+    </div>
+
+    <div class="video-link">
+      <iframe src="https://www.youtube.com/embed/kRWGWl6brkA" allowfullscreen></iframe>
+    </div>
+
   </main>
 
 </body>


### PR DESCRIPTION
## Summary
- convert highlights page to 2x2 grid and insert new YouTube clip
- style grid layout for uniform video sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689968bd7144832a9032c149a99d59a4