### PR TITLE
Add crawler files and non-JS highlight fallback

### DIFF
--- a/highlights/index.html
+++ b/highlights/index.html
@@ -33,18 +33,22 @@
 
     <div class="video-link">
       <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen></iframe>
+      <noscript><a href="https://www.youtube.com/watch?v=UyWX_CNWYX8" target="_blank">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
       <iframe src="https://www.youtube.com/embed/8xX1yvvVVNE" allowfullscreen></iframe>
+      <noscript><a href="https://www.youtube.com/watch?v=8xX1yvvVVNE" target="_blank">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
       <iframe src="https://www.youtube.com/embed/FmUmwU6VAus" allowfullscreen></iframe>
+      <noscript><a href="https://www.youtube.com/watch?v=FmUmwU6VAus" target="_blank">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
       <iframe src="https://www.youtube.com/embed/kRWGWl6brkA" allowfullscreen></iframe>
+      <noscript><a href="https://www.youtube.com/watch?v=kRWGWl6brkA" target="_blank">Watch on YouTube</a></noscript>
     </div>
 
   </main>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://lostless.live/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://lostless.live/</loc>
+  </url>
+  <url>
+    <loc>https://lostless.live/about/</loc>
+  </url>
+  <url>
+    <loc>https://lostless.live/contact/</loc>
+  </url>
+  <url>
+    <loc>https://lostless.live/highlights/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- expose sitemap in robots.txt so search crawlers can discover site pages
- add sitemap.xml listing the site’s key URLs
- add `<noscript>` links to highlights videos so page has content without JavaScript

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `ps -ef | grep http.server | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68996a454218832ab447db71abe5153d