### PR TITLE
Fade in lazy-loaded media

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -152,6 +152,16 @@ nav a.active {
   display: block;
 }
 
+/* Lazy-loaded media fade-in */
+.lazy-media {
+  opacity: 0;
+  transition: opacity 1s ease-in-out;
+}
+
+.lazy-media.loaded {
+  opacity: 1;
+}
+
 /* Responsive */
 @media (max-width: 1024px) {
   .gallery-grid {

--- a/index.html
+++ b/index.html
@@ -365,6 +365,20 @@
   <script>
     document.addEventListener('DOMContentLoaded', function () {
 
+      const lazyMedia = document.querySelectorAll('img[loading="lazy"], video[loading="lazy"]');
+      lazyMedia.forEach(media => {
+        const isVideo = media.tagName.toLowerCase() === 'video';
+        const alreadyLoaded = isVideo ? media.readyState >= 2 : media.complete;
+        if (alreadyLoaded) return;
+        media.classList.add('lazy-media');
+        const onLoaded = () => media.classList.add('loaded');
+        if (isVideo) {
+          media.addEventListener('loadeddata', onLoaded, { once: true });
+        } else {
+          media.addEventListener('load', onLoaded, { once: true });
+        }
+      });
+
       document.querySelectorAll('.gallery-item').forEach(item => {
         item.addEventListener('click', () => {
           const media = item.querySelector('img, video');


### PR DESCRIPTION
## Summary
- Fade in lazy-loaded images and videos on load or `loadeddata`
- Add helper script to skip already-visible media
- Introduce CSS classes for media opacity transition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1d503f64832abb41d9fa8b1fabb6