### PR TITLE
Optimize hero image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/css/styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/assets/favicon/favicon.ico">
+  <link rel="preload" as="image" href="/assets/meta/logo-big.png">
   <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
 
 </head>
@@ -29,12 +30,10 @@
     </nav>
   </header>
 
-  <div class="logo-big">
-    <img src="/assets/meta/logo-big.png" alt="lostless large logo" />
-  </div>
-
   <main>
- 
+    <div class="logo-big">
+      <img src="/assets/meta/logo-big.png" alt="lostless large logo" width="512" height="512" fetchpriority="high" decoding="async" />
+    </div>
 
     <section class="gallery-grid grid">
   <div class="gallery-item">


### PR DESCRIPTION
## Summary
- preload the main hero logo image for faster discovery
- move the hero image ahead of the gallery and mark it high priority with explicit dimensions

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_689a2402ac5c832a86895bf8124e980d