### PR TITLE
Refine about page copy and scatter effect

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,10 +34,10 @@
       i make visuals for live music, film, and installations using a variety of tools like python, touchdesigner and comfyui
     </p>
     <p>
-      my work often blends real-time effects with dreamlike ai-generated sequences
+      my work often blends real-time effects with dreamlike ai-generated sequences. i'm interested in generating visuals that are particularly difficult for people to create on their own
     </p>
     <p><em>simply put</em></p>
-      <p>i like when things don’t <span style="display:inline-block; transform: rotate(180deg) scaleX(-1);">behave</span> <span style="display:inline-block; transform: rotate(180deg);">behave</span> <span style="display:inline-block;">behave</span></p>
+      <p>i like when things don’t <span class="scatter-letter" style="display:inline-block; transform: translate(2px, -1px) rotate(-2deg);">b</span><span class="scatter-letter" style="display:inline-block; transform: translate(-1px, 3px) rotate(1deg);">e</span><span class="scatter-letter" style="display:inline-block; transform: translate(3px, 1px) rotate(-1deg);">h</span><span class="scatter-letter" style="display:inline-block; transform: translate(-2px, -3px) rotate(2deg);">a</span><span class="scatter-letter" style="display:inline-block; transform: translate(1px, 2px) rotate(-3deg);">v</span><span class="scatter-letter" style="display:inline-block; transform: translate(-3px, -1px) rotate(1deg);">e</span></p>
 
 
     <a href="https://www.instagram.com/lostless.visuals" target="_blank" onclick="plausible('Instagram Click')" style="display:inline-flex;align-items:center;gap:8px;text-decoration:none;color:#ff3366;margin-top:1.5rem;font-weight:600;">

--- a/css/styles.css
+++ b/css/styles.css
@@ -56,6 +56,11 @@ nav a.active {
   line-height: 1.6;
 }
 
+/* scatter effect letters */
+.scatter-letter {
+  display: inline-block;
+}
+
 /* Highlights video links */
 .video-link {
   display: block;


### PR DESCRIPTION
## Summary
- Update about page description with new sentence and punctuation
- Remove duplicated “behave” words and scatter remaining letters with subtle transforms
- Add reusable CSS class for scattered letters

## Testing
- `npm test` *(fails: enoent, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a28c56864832abed5ad5930c375c4