### PR TITLE
feat: interleave gallery items

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -115,7 +115,8 @@ nav a.active {
 
 /* Masonry Grid */
 .gallery-grid {
-  column-count: 4;
+  --cols: 3;
+  column-count: var(--cols);
   column-gap: 1rem;
   max-width: 1600px;
   margin: 0 auto;
@@ -165,13 +166,13 @@ nav a.active {
 /* Responsive */
 @media (max-width: 1024px) {
   .gallery-grid {
-    column-count: 2;
+    --cols: 2;
   }
 }
 
 @media (max-width: 600px) {
   .gallery-grid {
-    column-count: 2;
+    --cols: 1;
   }
 
   .site-logo img {

--- a/index.html
+++ b/index.html
@@ -364,6 +364,29 @@
   <script>
     document.addEventListener('DOMContentLoaded', function () {
 
+      const gallery = document.querySelector('.gallery-grid');
+      if (gallery) {
+        const items = Array.from(gallery.children);
+        const cols = parseInt(getComputedStyle(gallery).getPropertyValue('--cols')) || 1;
+        const rows = Math.ceil(items.length / cols);
+        const columns = [];
+        for (let c = 0; c < cols; c++) {
+          columns[c] = items.slice(c * rows, (c + 1) * rows);
+          const media = columns[c][0] && columns[c][0].querySelector('img, video');
+          if (media) {
+            media.setAttribute('fetchpriority', 'high');
+          }
+        }
+        const newOrder = [];
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            const item = columns[c][r];
+            if (item) newOrder.push(item);
+          }
+        }
+        gallery.append(...newOrder);
+      }
+
       const lazyMedia = document.querySelectorAll('img[loading="lazy"], video[loading="lazy"]');
       lazyMedia.forEach(media => {
         const isVideo = media.tagName.toLowerCase() === 'video';


### PR DESCRIPTION
## Summary
- reorder gallery items into row-major DOM order based on CSS column count
- boost initial images by marking first item of each column as `fetchpriority="high"`
- drive column count via `--cols` CSS variable for responsive layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a28b08b80832ab2727877face706e