### PR TITLE
Lazy load gallery videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,41 +295,41 @@
       <img src="/assets/images/image40.webp" alt="tiger-outline" width="608" height="1080" loading="lazy" decoding="async" />
     </picture>
   </div>
-  <div class="gallery-item"><video src="/assets/media/video1.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video10.mp4" autoplay muted loop playsinline width="606" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video11.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video12.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video13.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video14.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video15.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video16.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video17.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video18.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video19.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video2.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video20.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video21.mp4" autoplay muted loop playsinline width="610" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video22.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video23.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video24.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video25.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video26.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video27.mp4" autoplay muted loop playsinline width="1080" height="610" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video28.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video29.mp4" autoplay muted loop playsinline width="810" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video3.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video30.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video31.mp4" autoplay muted loop playsinline width="1088" height="1928" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video32.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video33.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video34.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video35.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video4.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video5.mp4" autoplay muted loop playsinline width="612" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video6.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video7.mp4" autoplay muted loop playsinline width="608" height="1080"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video8.mp4" autoplay muted loop playsinline width="608" height="1080" loading="lazy" decoding="async"></video></div>
-  <div class="gallery-item"><video src="/assets/media/video9.mp4" autoplay muted loop playsinline width="1080" height="608" loading="lazy" decoding="async"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video1.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video10.mp4" preload="none" muted loop playsinline width="606" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video11.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video12.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video13.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video14.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video15.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video16.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video17.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video18.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video19.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video2.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video20.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video21.mp4" preload="none" muted loop playsinline width="610" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video22.mp4" preload="none" muted loop playsinline width="810" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video23.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video24.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video25.mp4" preload="none" muted loop playsinline width="1080" height="610"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video26.mp4" preload="none" muted loop playsinline width="1080" height="610"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video27.mp4" preload="none" muted loop playsinline width="1080" height="610"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video28.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video29.mp4" preload="none" muted loop playsinline width="810" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video3.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video30.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video31.mp4" preload="none" muted loop playsinline width="1088" height="1928"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video32.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video33.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video34.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video35.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video4.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video5.mp4" preload="none" muted loop playsinline width="612" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video6.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video7.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video8.mp4" preload="none" muted loop playsinline width="608" height="1080"></video></div>
+  <div class="gallery-item"><video data-src="/assets/media/video9.mp4" preload="none" muted loop playsinline width="1080" height="608"></video></div>
   <div class="gallery-item">
     <picture>
       <source type="image/avif" srcset="/assets/images/image28.avif" />
@@ -361,35 +361,45 @@
 </section>
   </main>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        const lazyImages = document.querySelectorAll('img[loading="lazy"]');
+        lazyImages.forEach(img => {
+          if (img.complete) return;
+          img.classList.add('lazy-media');
+          img.addEventListener('load', () => img.classList.add('loaded'), { once: true });
+        });
 
-      const lazyMedia = document.querySelectorAll('img[loading="lazy"], video[loading="lazy"]');
-      lazyMedia.forEach(media => {
-        const isVideo = media.tagName.toLowerCase() === 'video';
-        const alreadyLoaded = isVideo ? media.readyState >= 2 : media.complete;
-        if (alreadyLoaded) return;
-        media.classList.add('lazy-media');
-        const onLoaded = () => media.classList.add('loaded');
-        if (isVideo) {
-          media.addEventListener('loadeddata', onLoaded, { once: true });
-        } else {
-          media.addEventListener('load', onLoaded, { once: true });
-        }
-      });
+        const lazyVideos = document.querySelectorAll('video[data-src]');
+        const observer = new IntersectionObserver((entries, obs) => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              const video = entry.target;
+              video.src = video.dataset.src;
+              video.load();
+              video.play();
+              obs.unobserve(video);
+            }
+          });
+        });
+        lazyVideos.forEach(video => {
+          video.classList.add('lazy-media');
+          video.addEventListener('loadeddata', () => video.classList.add('loaded'), { once: true });
+          observer.observe(video);
+        });
 
-      document.querySelectorAll('.gallery-item').forEach(item => {
-        item.addEventListener('click', () => {
-          const media = item.querySelector('img, video');
-          if (!media) return;
-          const slug = media.getAttribute('alt') || media.getAttribute('src').split('/').pop().split('.')[0];
-          if (window.plausible) {
-            plausible('Lightbox Open', { props: { item: slug } });
-          }
+        document.querySelectorAll('.gallery-item').forEach(item => {
+          item.addEventListener('click', () => {
+            const media = item.querySelector('img, video');
+            if (!media) return;
+            const slug = media.getAttribute('alt') || media.getAttribute('src').split('/').pop().split('.')[0];
+            if (window.plausible) {
+              plausible('Lightbox Open', { props: { item: slug } });
+            }
+          });
         });
       });
-    });
-  </script>
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace eager <video> sources with data-src and preload none
- Lazy-load videos via IntersectionObserver and fade in after loadeddata

## Testing
- `npm test` *(fails: Could not read package.json)*
- Attempted `pip install playwright` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a41e0ed8c832aabce6f667aeda305