### PR TITLE
fix: remove closing source tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,6 @@
       <source srcset="assets/images/image7-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image7-480.webp 480w" type="image/webp">
         <img alt="audio-react" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image7.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -65,8 +63,6 @@
       <source srcset="assets/images/image41-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image41-480.webp 480w" type="image/webp">
         <img alt="blob-tracking" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image41.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -74,8 +70,6 @@
       <source srcset="assets/images/image31-1080.avif 1080w, assets/images/image31-480.avif 480w, assets/images/image31-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image31-1080.webp 1080w, assets/images/image31-480.webp 480w, assets/images/image31-800.webp 800w" type="image/webp">
         <img alt="blood-cherry-blossom" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image31.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -83,8 +77,6 @@
       <source srcset="assets/images/image33-1080.avif 1080w, assets/images/image33-480.avif 480w, assets/images/image33-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image33-1080.webp 1080w, assets/images/image33-480.webp 480w, assets/images/image33-800.webp 800w" type="image/webp">
         <img alt="bloodrobot" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image33.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -92,8 +84,6 @@
       <source srcset="assets/images/image37-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image37-480.webp 480w" type="image/webp">
         <img alt="cubic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image37.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -101,8 +91,6 @@
       <source srcset="assets/images/image21-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image21-480.webp 480w" type="image/webp">
         <img alt="cyber" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image21.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -110,8 +98,6 @@
       <source srcset="assets/images/image14-1080.avif 1080w, assets/images/image14-480.avif 480w, assets/images/image14-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image14-1080.webp 1080w, assets/images/image14-480.webp 480w, assets/images/image14-800.webp 800w" type="image/webp">
         <img alt="digital" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image14.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -119,8 +105,6 @@
       <source srcset="assets/images/image8-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image8-480.webp 480w" type="image/webp">
         <img alt="explode" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image8.webp" width="612">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -128,8 +112,6 @@
       <source srcset="assets/images/image35-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image35-480.webp 480w" type="image/webp">
         <img alt="eye-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image35.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -137,8 +119,6 @@
       <source srcset="assets/images/image38-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image38-480.webp 480w" type="image/webp">
         <img alt="ghost" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image38.webp" width="606">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -146,8 +126,6 @@
       <source srcset="assets/images/image26-1080.avif 1080w, assets/images/image26-480.avif 480w, assets/images/image26-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image26-1080.webp 1080w, assets/images/image26-480.webp 480w, assets/images/image26-800.webp 800w" type="image/webp">
         <img alt="ghost-in-the-shell" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image26.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -155,8 +133,6 @@
       <source srcset="assets/images/image5-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image5-480.webp 480w" type="image/webp">
         <img alt="installation" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image5.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -164,8 +140,6 @@
       <source srcset="assets/images/image17-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image17-480.webp 480w" type="image/webp">
         <img alt="jellyfish" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image17.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -173,8 +147,6 @@
       <source srcset="assets/images/image16-1080.avif 1080w, assets/images/image16-480.avif 480w, assets/images/image16-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image16-1080.webp 1080w, assets/images/image16-480.webp 480w, assets/images/image16-800.webp 800w" type="image/webp">
         <img alt="jellyfish-clouds" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image16.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -182,8 +154,6 @@
       <source srcset="assets/images/image18-1080.avif 1080w, assets/images/image18-480.avif 480w, assets/images/image18-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image18-1080.webp 1080w, assets/images/image18-480.webp 480w, assets/images/image18-800.webp 800w" type="image/webp">
         <img alt="jungle" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image18.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -191,8 +161,6 @@
       <source srcset="assets/images/image10-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image10-480.webp 480w" type="image/webp">
         <img alt="landscape" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image10.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -200,8 +168,6 @@
       <source srcset="assets/images/image27-1080.avif 1080w, assets/images/image27-480.avif 480w, assets/images/image27-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image27-1080.webp 1080w, assets/images/image27-480.webp 480w, assets/images/image27-800.webp 800w" type="image/webp">
         <img alt="liminal-space" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image27.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -209,8 +175,6 @@
       <source srcset="assets/images/image2-1080.avif 1080w, assets/images/image2-480.avif 480w, assets/images/image2-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image2-1080.webp 1080w, assets/images/image2-480.webp 480w, assets/images/image2-800.webp 800w" type="image/webp">
         <img alt="live-performance-warehouse" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image2.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -218,8 +182,6 @@
       <source srcset="assets/images/image3-480.avif 480w, assets/images/image3-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image3-480.webp 480w, assets/images/image3-800.webp 800w" type="image/webp">
         <img alt="livemusic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image3.webp" width="914">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -227,8 +189,6 @@
       <source srcset="assets/images/image23-1080.avif 1080w, assets/images/image23-480.avif 480w, assets/images/image23-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image23-1080.webp 1080w, assets/images/image23-480.webp 480w, assets/images/image23-800.webp 800w" type="image/webp">
         <img alt="lotus" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image23.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -236,8 +196,6 @@
       <source srcset="assets/images/image9-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image9-480.webp 480w" type="image/webp">
         <img alt="martial-arts" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image9.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -245,8 +203,6 @@
       <source srcset="assets/images/image15-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image15-480.webp 480w" type="image/webp">
         <img alt="necrosis" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image15.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -254,8 +210,6 @@
       <source srcset="assets/images/image20-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image20-480.webp 480w" type="image/webp">
         <img alt="octopus-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image20.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -263,8 +217,6 @@
       <source srcset="assets/images/image29-1080.avif 1080w, assets/images/image29-480.avif 480w, assets/images/image29-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image29-1080.webp 1080w, assets/images/image29-480.webp 480w, assets/images/image29-800.webp 800w" type="image/webp">
         <img alt="plants" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image29.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -272,8 +224,6 @@
       <source srcset="assets/images/image32-1080.avif 1080w, assets/images/image32-480.avif 480w, assets/images/image32-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image32-1080.webp 1080w, assets/images/image32-480.webp 480w, assets/images/image32-800.webp 800w" type="image/webp">
         <img alt="poison" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image32.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -281,8 +231,6 @@
       <source srcset="assets/images/image13-1080.avif 1080w, assets/images/image13-480.avif 480w, assets/images/image13-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image13-1080.webp 1080w, assets/images/image13-480.webp 480w, assets/images/image13-800.webp 800w" type="image/webp">
         <img alt="shell" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image13.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -290,8 +238,6 @@
       <source srcset="assets/images/image6-1080.avif 1080w, assets/images/image6-480.avif 480w, assets/images/image6-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image6-1080.webp 1080w, assets/images/image6-480.webp 480w, assets/images/image6-800.webp 800w" type="image/webp">
         <img alt="skull-art" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image6.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -299,8 +245,6 @@
       <source srcset="assets/images/image24-1080.avif 1080w, assets/images/image24-480.avif 480w, assets/images/image24-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image24-1080.webp 1080w, assets/images/image24-480.webp 480w, assets/images/image24-800.webp 800w" type="image/webp">
         <img alt="slime-installation" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image24.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -308,8 +252,6 @@
       <source srcset="assets/images/image39-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image39-480.webp 480w" type="image/webp">
         <img alt="snake-green" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image39.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -317,8 +259,6 @@
       <source srcset="assets/images/image34-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image34-480.webp 480w" type="image/webp">
         <img alt="snake-queen" decoding="async" fetchpriority="high" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image34.webp" width="607">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -326,8 +266,6 @@
       <source srcset="assets/images/image30-1080.avif 1080w, assets/images/image30-480.avif 480w, assets/images/image30-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image30-1080.webp 1080w, assets/images/image30-480.webp 480w, assets/images/image30-800.webp 800w" type="image/webp">
         <img alt="solar" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image30.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -335,8 +273,6 @@
       <source srcset="assets/images/image19-1080.avif 1080w, assets/images/image19-480.avif 480w, assets/images/image19-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image19-1080.webp 1080w, assets/images/image19-480.webp 480w, assets/images/image19-800.webp 800w" type="image/webp">
         <img alt="spectre" decoding="async" height="606" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image19.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -344,8 +280,6 @@
       <source srcset="assets/images/image36-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image36-480.webp 480w" type="image/webp">
         <img alt="squares" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image36.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -353,8 +287,6 @@
       <source srcset="assets/images/image12-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image12-480.webp 480w" type="image/webp">
         <img alt="surreal" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image12.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -362,8 +294,6 @@
       <source srcset="assets/images/image22-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image22-480.webp 480w" type="image/webp">
         <img alt="technicolor" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image22.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -371,8 +301,6 @@
       <source srcset="assets/images/image25-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image25-480.webp 480w" type="image/webp">
         <img alt="tiger" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image25.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -380,8 +308,6 @@
       <source srcset="assets/images/image40-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image40-480.webp 480w" type="image/webp">
         <img alt="tiger-outline" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image40.webp" width="608">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -599,8 +525,6 @@
       <source srcset="assets/images/image28-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image28-480.webp 480w" type="image/webp">
         <img alt="villan" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image28.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -608,8 +532,6 @@
       <source srcset="assets/images/image4-480.avif 480w, assets/images/image4-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image4-480.webp 480w, assets/images/image4-800.webp 800w" type="image/webp">
         <img alt="vj-live" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image4.webp" width="810">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -617,8 +539,6 @@
       <source srcset="assets/images/image1-1080.avif 1080w, assets/images/image1-480.avif 480w, assets/images/image1-800.avif 800w" type="image/avif">
        <source srcset="assets/images/image1-1080.webp 1080w, assets/images/image1-480.webp 480w, assets/images/image1-800.webp 800w" type="image/webp">
         <img alt="vjing" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image1.webp" width="1080">
-       </source>
-      </source>
      </picture>
     </div>
     <div class="gallery-item">
@@ -626,8 +546,6 @@
       <source srcset="assets/images/image11-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image11-480.webp 480w" type="image/webp">
         <img alt="yellow-devil" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image11.webp" width="609">
-       </source>
-      </source>
      </picture>
     </div>
    </section>


### PR DESCRIPTION
## Summary
- fix source tags: `<source>` is self-closing; removed unnecessary `</source>` closers across index.html

## Testing
- `python - <<'PY'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def error(self, message):
        print('Error:', message)
with open('index.html') as f:
    MyParser().feed(f.read())
print('Parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689a6e67dce8832aae8571f66eb21ba2