### PR TITLE
Add canonical link tags to main pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -7,11 +7,12 @@
   <meta name="description" content="lostless is an audiovisual artist creating immersive visual experiences using AI and real-time tools.">
   <meta name="author" content="lostless">
   <!--#include virtual="/includes/meta-social.html" -->
-  <link rel="stylesheet" href="/css/styles.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/favicon/favicon.ico">
-  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
-</head>
+    <link rel="stylesheet" href="/css/styles.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/favicon/favicon.ico">
+    <link rel="canonical" href="https://lostless.live/about/">
+    <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
+  </head>
 <body>
 
   <header>

--- a/contact/index.html
+++ b/contact/index.html
@@ -7,11 +7,12 @@
   <meta name="description" content="get in touch with lostless for bookings, commissions, or collaborations.">
   <meta name="author" content="lostless">
   <!--#include virtual="/includes/meta-social.html" -->
-  <link rel="stylesheet" href="/css/styles.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/favicon/favicon.ico">
-  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
-</head>
+    <link rel="stylesheet" href="/css/styles.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/favicon/favicon.ico">
+    <link rel="canonical" href="https://lostless.live/contact/">
+    <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
+  </head>
 <body style="background-color: #000;">
 
   <header>

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -8,11 +8,12 @@
   <meta name="description" content="selected works and showreels by lostless: live performance, touchdesigner, and AI visuals.">
   <meta name="author" content="lostless">
   <!--#include virtual="/includes/meta-social.html" -->
-  <link rel="stylesheet" href="/css/styles.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="icon" href="/assets/favicon/favicon.ico">
-  <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
-</head>
+    <link rel="stylesheet" href="/css/styles.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" href="/assets/favicon/favicon.ico">
+    <link rel="canonical" href="https://lostless.live/highlights/">
+    <script defer data-domain="lostless.live" src="https://plausible.io/js/script.js"></script>
+  </head>
 <body>
 
   <header>

--- a/index.html
+++ b/index.html
@@ -7,15 +7,16 @@
    lostless &mdash; work
   </title>
   <meta content="generative visuals for live performance, music videos, and installations using touchdesigner, comfyui, and real-time ai tools." name="description">
-  <meta content="lostless" name="author">
-  <!--#include virtual="/includes/meta-social.html" -->
-  <link href="/css/styles.css" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link href="/assets/favicon/favicon.ico" rel="icon">
-  <link as="image" href="/assets/meta/logo-big.png" rel="preload">
-  <script data-domain="lostless.live" defer src="https://plausible.io/js/script.js">
-  </script>
- </head>
+   <meta content="lostless" name="author">
+   <!--#include virtual="/includes/meta-social.html" -->
+   <link href="/css/styles.css" rel="stylesheet">
+   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+   <link href="/assets/favicon/favicon.ico" rel="icon">
+   <link rel="canonical" href="https://lostless.live/">
+   <link as="image" href="/assets/meta/logo-big.png" rel="preload">
+   <script data-domain="lostless.live" defer src="https://plausible.io/js/script.js">
+   </script>
+   </head>
  <body style="background-color: #000;">
   <header>
    <nav>


### PR DESCRIPTION
## Summary
- add canonical link for homepage
- add canonical links for about, contact, and highlights pages

## Testing
- `python - <<'PY'
import html.parser
class CanonicalParser(html.parser.HTMLParser):
    def __init__(self):
        super().__init__()
        self.canonical=None
    def handle_starttag(self, tag, attrs):
        if tag.lower()=='link':
            attrs=dict(attrs)
            if attrs.get('rel')=='canonical':
                self.canonical=attrs.get('href')

for p in ['index.html','about/index.html','contact/index.html','highlights/index.html']:
    parser=CanonicalParser()
    parser.feed(open(p).read())
    print(p, '->', parser.canonical)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a710d2784832a83b225773ea5a4c3