### PR TITLE
Add sandbox attributes to highlight iframes

### DIFF
--- a/highlights/index.html
+++ b/highlights/index.html
@@ -36,22 +36,22 @@
   <main class="centered-section highlights-grid">
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=UyWX_CNWYX8" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/8xX1yvvVVNE" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/8xX1yvvVVNE" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=8xX1yvvVVNE" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/FmUmwU6VAus" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/FmUmwU6VAus" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=FmUmwU6VAus" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/kRWGWl6brkA" allowfullscreen></iframe>
+      <iframe src="https://www.youtube.com/embed/kRWGWl6brkA" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=kRWGWl6brkA" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 


### PR DESCRIPTION
## Summary
- secure YouTube embeds on the highlights page with sandbox, no-referrer, and lazy loading attributes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa11d34c4832aa198ecbd74c6f5e7