### PR TITLE
Fix broken YouTube embed and restore contact email

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.youtube.com;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.youtube-nocookie.com https://www.youtube.com;" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>contact — lostless</title>
@@ -36,15 +36,7 @@
   <main class="centered-section">
     <p>inquiries, bookings, commissions:</p>
 
-    <a id="email-link" class="contact-link" onclick="plausible('Contact Email')"></a>
-    <script>
-      const u = "lostless.visuals";
-      const d = "gmail.com";
-      const email = u + "@" + d;
-      const link = document.getElementById("email-link");
-      link.href = "mailto:" + email;
-      link.textContent = email;
-    </script>
+    <a href="mailto:lostless.visuals@gmail.com" class="contact-link" onclick="plausible('Contact Email')">lostless.visuals@gmail.com</a>
 
     <p style="margin-top: 2rem;">
       or dm on instagram:<br>

--- a/highlights/index.html
+++ b/highlights/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.youtube.com;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.youtube-nocookie.com https://www.youtube.com;" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>lostless — highlights</title>
@@ -37,7 +37,7 @@
   <main class="centered-section highlights-grid">
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
+      <iframe src="https://www.youtube-nocookie.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=UyWX_CNWYX8" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 


### PR DESCRIPTION
## Summary
- Update highlights page to load YouTube video from `youtube-nocookie.com` and allow that domain in CSP
- Make contact email visible again with a direct `mailto` link and updated CSP

## Testing
- `npx --yes htmlhint highlights/index.html contact/index.html` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_689b7491f6bc832aaf353a15041643c3