### PR TITLE
fix broken highlights youtube link

### DIFF
--- a/highlights/index.html
+++ b/highlights/index.html
@@ -37,7 +37,7 @@
   <main class="centered-section highlights-grid">
 
     <div class="video-link">
-      <iframe src="https://www.youtube-nocookie.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
+      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=UyWX_CNWYX8" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 


### PR DESCRIPTION
## Summary
- update highlights page to use standard youtube embed URL for UyWX_CNWYX8

## Testing
- `npx --yes htmlhint highlights/index.html` *(fails: 403 Forbidden)*
- `tidy -errors highlights/index.html` *(fails: command not found)*
- `python -m html5validator highlights/index.html` *(fails: No module named html5validator)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e8adaec832ab1d9c903fb315f4c