### PR TITLE
Allow YouTube embeds by expanding CSP

### DIFF
--- a/highlights/index.html
+++ b/highlights/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; frame-src https://www.youtube-nocookie.com https://www.youtube.com;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; child-src https://*.youtube.com https://*.youtube-nocookie.com; frame-src https://*.youtube.com https://*.youtube-nocookie.com;">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>lostless — highlights</title>
@@ -37,7 +37,7 @@
   <main class="centered-section highlights-grid">
 
     <div class="video-link">
-      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allowfullscreen sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" loading="lazy"></iframe>
+      <iframe src="https://www.youtube.com/embed/UyWX_CNWYX8" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="no-referrer" loading="lazy"></iframe>
       <noscript><a href="https://www.youtube.com/watch?v=UyWX_CNWYX8" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></noscript>
     </div>
 


### PR DESCRIPTION
## Summary
- Relax Content Security Policy to allow child iframes from YouTube domains
- Remove sandbox from the first highlight iframe and grant required playback permissions

## Testing
- `npx --yes htmlhint highlights/index.html` *(fails: 403 Forbidden from registry.npmjs.org)*
- `npx --yes playwright install chromium` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_689b91a57bb0832a90e9e91de66b00ba