### PR TITLE
Publish latest homepage masonry reshuffles

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,63 +177,9 @@
    </section>
   <section class="gallery-grid grid">
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image49-1080.avif 704w, assets/images/image49-800.avif 704w, assets/images/image49-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image49-1080.webp 704w, assets/images/image49-800.webp 704w, assets/images/image49-480.webp 480w" type="image/webp">
-        <img alt="magnetic-pulse" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image49.webp" width="704">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image32-1080.avif 1080w, assets/images/image32-480.avif 480w, assets/images/image32-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image32-1080.webp 1080w, assets/images/image32-480.webp 480w, assets/images/image32-800.webp 800w" type="image/webp">
-        <img alt="poison" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image32.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image28-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image28-480.webp 480w" type="image/webp">
-        <img alt="villan" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image28.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image11-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image11-480.webp 480w" type="image/webp">
-        <img alt="yellow-devil" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image11.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image29-1080.avif 1080w, assets/images/image29-480.avif 480w, assets/images/image29-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image29-1080.webp 1080w, assets/images/image29-480.webp 480w, assets/images/image29-800.webp 800w" type="image/webp">
-        <img alt="plants" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image29.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video60.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video60.webm" type="video/webm">
-      <source data-src="assets/media/video60.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video6.jpg" preload="none" width="608">
-      <source data-src="assets/media/video6.webm" type="video/webm">
-      <source data-src="assets/media/video6.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image68-1080.avif 1080w, assets/images/image68-480.avif 480w, assets/images/image68-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image68-1080.webp 1080w, assets/images/image68-480.webp 480w, assets/images/image68-800.webp 800w" type="image/webp">
-        <img alt="spiked-floral-study" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image68.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video17.jpg" preload="none" width="608">
-      <source data-src="assets/media/video17.webm" type="video/webm">
-      <source data-src="assets/media/video17.mp4" type="video/mp4">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video14.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video14.webm" type="video/webm">
+      <source data-src="assets/media/video14.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -244,295 +190,22 @@
      </picture>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image12-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image12-480.webp 480w" type="image/webp">
-        <img alt="surreal" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image12.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image51-1080.avif 704w, assets/images/image51-800.avif 704w, assets/images/image51-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image51-1080.webp 704w, assets/images/image51-800.webp 704w, assets/images/image51-480.webp 480w" type="image/webp">
-        <img alt="cosmic-orchid" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image51.webp" width="704">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video72.jpg" preload="none" width="612">
-      <source data-src="assets/media/video72.webm" type="video/webm">
-      <source data-src="assets/media/video72.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video77.jpg" preload="none" width="606">
+      <source data-src="assets/media/video77.webm" type="video/webm">
+      <source data-src="assets/media/video77.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video42.jpg" preload="none" width="606">
-      <source data-src="assets/media/video42.webm" type="video/webm">
-      <source data-src="assets/media/video42.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video33.jpg" preload="none" width="608">
+      <source data-src="assets/media/video33.webm" type="video/webm">
+      <source data-src="assets/media/video33.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image36-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image36-480.webp 480w" type="image/webp">
-        <img alt="squares" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image36.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video29.jpg" preload="none" width="810">
-      <source data-src="assets/media/video29.webm" type="video/webm">
-      <source data-src="assets/media/video29.mp4" type="video/mp4">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video75.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video75.webm" type="video/webm">
+      <source data-src="assets/media/video75.mp4" type="video/mp4">
      </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video70.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video70.webm" type="video/webm">
-      <source data-src="assets/media/video70.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image64-1080.avif 1080w, assets/images/image64-480.avif 480w, assets/images/image64-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image64-1080.webp 1080w, assets/images/image64-480.webp 480w, assets/images/image64-800.webp 800w" type="image/webp">
-        <img alt="live-performance-radial" class="lazy-fade" decoding="async" fetchpriority="high" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image64.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image55-1080.avif 1080w, assets/images/image55-800.avif 800w, assets/images/image55-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image55-1080.webp 1080w, assets/images/image55-800.webp 800w, assets/images/image55-480.webp 480w" type="image/webp">
-        <img alt="stellar-storm" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image55.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image63-1080.avif 1024w, assets/images/image63-800.avif 800w, assets/images/image63-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image63-1080.webp 1024w, assets/images/image63-800.webp 800w, assets/images/image63-480.webp 480w" type="image/webp">
-        <img alt="velvet-thunder" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image63.webp" width="1024">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image45-1080.avif 576w, assets/images/image45-800.avif 576w, assets/images/image45-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image45-1080.webp 576w, assets/images/image45-800.webp 576w, assets/images/image45-480.webp 480w" type="image/webp">
-        <img alt="holographic-wave" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image45.webp" width="576">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image44-1080.avif 1080w, assets/images/image44-800.avif 800w, assets/images/image44-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image44-1080.webp 1080w, assets/images/image44-800.webp 800w, assets/images/image44-480.webp 480w" type="image/webp">
-        <img alt="nebula-veil" decoding="async" height="902" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image44.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video44.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video44.webm" type="video/webm">
-      <source data-src="assets/media/video44.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video62.jpg" preload="none" width="594">
-      <source data-src="assets/media/video62.webm" type="video/webm">
-      <source data-src="assets/media/video62.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video23.jpg" preload="none" width="608">
-      <source data-src="assets/media/video23.webm" type="video/webm">
-      <source data-src="assets/media/video23.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image10-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image10-480.webp 480w" type="image/webp">
-        <img alt="landscape" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image10.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video7.jpg" preload="none" width="608">
-      <source data-src="assets/media/video7.webm" type="video/webm">
-      <source data-src="assets/media/video7.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video30.jpg" preload="none" width="608">
-      <source data-src="assets/media/video30.webm" type="video/webm">
-      <source data-src="assets/media/video30.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image60-1080.avif 1080w, assets/images/image60-800.avif 800w, assets/images/image60-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image60-1080.webp 1080w, assets/images/image60-800.webp 800w, assets/images/image60-480.webp 480w" type="image/webp">
-        <img alt="nova-swarm" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image60.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video20.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video20.webm" type="video/webm">
-      <source data-src="assets/media/video20.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video76.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video76.webm" type="video/webm">
-      <source data-src="assets/media/video76.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image39-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image39-480.webp 480w" type="image/webp">
-        <img alt="snake-green" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image39.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image65-1080.avif 1080w, assets/images/image65-480.avif 480w, assets/images/image65-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image65-1080.webp 1080w, assets/images/image65-480.webp 480w, assets/images/image65-800.webp 800w" type="image/webp">
-        <img alt="lostless-live-performance-wall" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image65.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video36.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video36.webm" type="video/webm">
-      <source data-src="assets/media/video36.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video50.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video50.webm" type="video/webm">
-      <source data-src="assets/media/video50.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video21.jpg" preload="none" width="610">
-      <source data-src="assets/media/video21.webm" type="video/webm">
-      <source data-src="assets/media/video21.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video11.jpg" preload="none" width="608">
-      <source data-src="assets/media/video11.webm" type="video/webm">
-      <source data-src="assets/media/video11.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video28.jpg" preload="none" width="608">
-      <source data-src="assets/media/video28.webm" type="video/webm">
-      <source data-src="assets/media/video28.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video34.jpg" preload="none" width="608">
-      <source data-src="assets/media/video34.webm" type="video/webm">
-      <source data-src="assets/media/video34.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image3-480.avif 480w, assets/images/image3-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image3-480.webp 480w, assets/images/image3-800.webp 800w" type="image/webp">
-        <img alt="livemusic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image3.webp" width="914">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video4.jpg" preload="none" width="608">
-      <source data-src="assets/media/video4.webm" type="video/webm">
-      <source data-src="assets/media/video4.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image22-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image22-480.webp 480w" type="image/webp">
-        <img alt="technicolor" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image22.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image27-1080.avif 1080w, assets/images/image27-480.avif 480w, assets/images/image27-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image27-1080.webp 1080w, assets/images/image27-480.webp 480w, assets/images/image27-800.webp 800w" type="image/webp">
-        <img alt="liminal-space" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image27.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video40.jpg" preload="none" width="608">
-      <source data-src="assets/media/video40.webm" type="video/webm">
-      <source data-src="assets/media/video40.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image5-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image5-480.webp 480w" type="image/webp">
-        <img alt="installation" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image5.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image70-1080.avif 1080w, assets/images/image70-480.avif 480w, assets/images/image70-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image70-1080.webp 1080w, assets/images/image70-480.webp 480w, assets/images/image70-800.webp 800w" type="image/webp">
-        <img alt="headphones-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image70.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video32.jpg" preload="none" width="608">
-      <source data-src="assets/media/video32.webm" type="video/webm">
-      <source data-src="assets/media/video32.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video12.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video12.webm" type="video/webm">
-      <source data-src="assets/media/video12.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video22.jpg" preload="none" width="810">
-      <source data-src="assets/media/video22.webm" type="video/webm">
-      <source data-src="assets/media/video22.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image9-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image9-480.webp 480w" type="image/webp">
-        <img alt="martial-arts" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image9.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image24-1080.avif 1080w, assets/images/image24-480.avif 480w, assets/images/image24-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image24-1080.webp 1080w, assets/images/image24-480.webp 480w, assets/images/image24-800.webp 800w" type="image/webp">
-        <img alt="slime-installation" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image24.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image8-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image8-480.webp 480w" type="image/webp">
-        <img alt="explode" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image8.webp" width="612">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video52.jpg" preload="none" width="606">
-      <source data-src="assets/media/video52.webm" type="video/webm">
-      <source data-src="assets/media/video52.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video1.jpg" preload="none" width="608">
-      <source data-src="assets/media/video1.webm" type="video/webm">
-      <source data-src="assets/media/video1.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image58-1080.avif 1080w, assets/images/image58-800.avif 800w, assets/images/image58-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image58-1080.webp 1080w, assets/images/image58-800.webp 800w, assets/images/image58-480.webp 480w" type="image/webp">
-        <img alt="ember-cloud" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image58.webp" width="1080">
-     </picture>
     </div>
     <div class="gallery-item">
      <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video26.jpg" preload="none" width="1080">
@@ -541,99 +214,11 @@
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video73.jpg" preload="none" width="612">
-      <source data-src="assets/media/video73.webm" type="video/webm">
-      <source data-src="assets/media/video73.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="612" loop muted playsinline poster="assets/media/video71.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video71.webm" type="video/webm">
-      <source data-src="assets/media/video71.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video48.jpg" preload="none" width="606">
-      <source data-src="assets/media/video48.webm" type="video/webm">
-      <source data-src="assets/media/video48.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image15-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image15-480.webp 480w" type="image/webp">
-        <img alt="necrosis" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image15.webp" width="609">
+      <source srcset="assets/images/image11-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image11-480.webp 480w" type="image/webp">
+        <img alt="yellow-devil" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image11.webp" width="609">
      </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video13.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video13.webm" type="video/webm">
-      <source data-src="assets/media/video13.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image26-1080.avif 1080w, assets/images/image26-480.avif 480w, assets/images/image26-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image26-1080.webp 1080w, assets/images/image26-480.webp 480w, assets/images/image26-800.webp 800w" type="image/webp">
-        <img alt="ghost-in-the-shell" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image26.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image13-1080.avif 1080w, assets/images/image13-480.avif 480w, assets/images/image13-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image13-1080.webp 1080w, assets/images/image13-480.webp 480w, assets/images/image13-800.webp 800w" type="image/webp">
-        <img alt="shell" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image13.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image38-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image38-480.webp 480w" type="image/webp">
-        <img alt="ghost" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image38.webp" width="606">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video15.jpg" preload="none" width="608">
-      <source data-src="assets/media/video15.webm" type="video/webm">
-      <source data-src="assets/media/video15.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video64.jpg" preload="none" width="594">
-      <source data-src="assets/media/video64.webm" type="video/webm">
-      <source data-src="assets/media/video64.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video56.jpg" preload="none" width="606">
-      <source data-src="assets/media/video56.webm" type="video/webm">
-      <source data-src="assets/media/video56.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image35-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image35-480.webp 480w" type="image/webp">
-        <img alt="eye-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image35.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video54.jpg" preload="none" width="606">
-      <source data-src="assets/media/video54.webm" type="video/webm">
-      <source data-src="assets/media/video54.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video74.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video74.webm" type="video/webm">
-      <source data-src="assets/media/video74.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video5.jpg" preload="none" width="612">
-      <source data-src="assets/media/video5.webm" type="video/webm">
-      <source data-src="assets/media/video5.mp4" type="video/mp4">
-     </video>
     </div>
     <div class="gallery-item">
      <picture>
@@ -643,15 +228,61 @@
      </picture>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video75.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video75.webm" type="video/webm">
-      <source data-src="assets/media/video75.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image53-1080.avif 1080w, assets/images/image53-800.avif 800w, assets/images/image53-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image53-1080.webp 1080w, assets/images/image53-800.webp 800w, assets/images/image53-480.webp 480w" type="image/webp">
+        <img alt="mirror-forest" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image53.webp" width="1280">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video5.jpg" preload="none" width="612">
+      <source data-src="assets/media/video5.webm" type="video/webm">
+      <source data-src="assets/media/video5.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video33.jpg" preload="none" width="608">
-      <source data-src="assets/media/video33.webm" type="video/webm">
-      <source data-src="assets/media/video33.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image70-1080.avif 1080w, assets/images/image70-480.avif 480w, assets/images/image70-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image70-1080.webp 1080w, assets/images/image70-480.webp 480w, assets/images/image70-800.webp 800w" type="image/webp">
+        <img alt="headphones-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image70.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video42.jpg" preload="none" width="606">
+      <source data-src="assets/media/video42.webm" type="video/webm">
+      <source data-src="assets/media/video42.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image38-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image38-480.webp 480w" type="image/webp">
+        <img alt="ghost" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image38.webp" width="606">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video36.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video36.webm" type="video/webm">
+      <source data-src="assets/media/video36.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video72.jpg" preload="none" width="612">
+      <source data-src="assets/media/video72.webm" type="video/webm">
+      <source data-src="assets/media/video72.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image23-1080.avif 1080w, assets/images/image23-480.avif 480w, assets/images/image23-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image23-1080.webp 1080w, assets/images/image23-480.webp 480w, assets/images/image23-800.webp 800w" type="image/webp">
+        <img alt="lotus" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image23.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video38.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video38.webm" type="video/webm">
+      <source data-src="assets/media/video38.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -663,184 +294,34 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image18-1080.avif 1080w, assets/images/image18-480.avif 480w, assets/images/image18-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image18-1080.webp 1080w, assets/images/image18-480.webp 480w, assets/images/image18-800.webp 800w" type="image/webp">
-        <img alt="jungle" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image18.webp" width="1080">
+      <source srcset="assets/images/image5-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image5-480.webp 480w" type="image/webp">
+        <img alt="installation" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image5.webp" width="608">
      </picture>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image30-1080.avif 1080w, assets/images/image30-480.avif 480w, assets/images/image30-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image30-1080.webp 1080w, assets/images/image30-480.webp 480w, assets/images/image30-800.webp 800w" type="image/webp">
-        <img alt="solar" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image30.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video68.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video68.webm" type="video/webm">
-      <source data-src="assets/media/video68.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video21.jpg" preload="none" width="610">
+      <source data-src="assets/media/video21.webm" type="video/webm">
+      <source data-src="assets/media/video21.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video19.jpg" preload="none" width="608">
-      <source data-src="assets/media/video19.webm" type="video/webm">
-      <source data-src="assets/media/video19.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video22.jpg" preload="none" width="810">
+      <source data-src="assets/media/video22.webm" type="video/webm">
+      <source data-src="assets/media/video22.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video77.jpg" preload="none" width="606">
-      <source data-src="assets/media/video77.webm" type="video/webm">
-      <source data-src="assets/media/video77.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video23.jpg" preload="none" width="608">
+      <source data-src="assets/media/video23.webm" type="video/webm">
+      <source data-src="assets/media/video23.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image42-1080.avif 1080w, assets/images/image42-800.avif 800w, assets/images/image42-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image42-1080.webp 1080w, assets/images/image42-800.webp 800w, assets/images/image42-480.webp 480w" type="image/webp">
-        <img alt="crystal-drift" decoding="async" height="1066" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image42.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1928" loop muted playsinline poster="assets/media/video31.jpg" preload="none" width="1088">
-      <source data-src="assets/media/video31.webm" type="video/webm">
-      <source data-src="assets/media/video31.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image54-1080.avif 1080w, assets/images/image54-800.avif 800w, assets/images/image54-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image54-1080.webp 1080w, assets/images/image54-800.webp 800w, assets/images/image54-480.webp 480w" type="image/webp">
-        <img alt="skyline-glitch" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image54.webp" width="1280">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video2.jpg" preload="none" width="608">
-      <source data-src="assets/media/video2.webm" type="video/webm">
-      <source data-src="assets/media/video2.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image23-1080.avif 1080w, assets/images/image23-480.avif 480w, assets/images/image23-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image23-1080.webp 1080w, assets/images/image23-480.webp 480w, assets/images/image23-800.webp 800w" type="image/webp">
-        <img alt="lotus" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image23.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video58.jpg" preload="none" width="606">
-      <source data-src="assets/media/video58.webm" type="video/webm">
-      <source data-src="assets/media/video58.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video46.jpg" preload="none" width="606">
-      <source data-src="assets/media/video46.webm" type="video/webm">
-      <source data-src="assets/media/video46.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video24.jpg" preload="none" width="608">
-      <source data-src="assets/media/video24.webm" type="video/webm">
-      <source data-src="assets/media/video24.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image4-480.avif 480w, assets/images/image4-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image4-480.webp 480w, assets/images/image4-800.webp 800w" type="image/webp">
-        <img alt="vj-live" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image4.webp" width="810">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image61-1080.avif 1080w, assets/images/image61-800.avif 800w, assets/images/image61-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image61-1080.webp 1080w, assets/images/image61-800.webp 800w, assets/images/image61-480.webp 480w" type="image/webp">
-        <img alt="petal-maelstrom" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image61.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video38.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video38.webm" type="video/webm">
-      <source data-src="assets/media/video38.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video66.jpg" preload="none" width="594">
-      <source data-src="assets/media/video66.webm" type="video/webm">
-      <source data-src="assets/media/video66.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image20-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image20-480.webp 480w" type="image/webp">
-        <img alt="octopus-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image20.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video18.jpg" preload="none" width="608">
-      <source data-src="assets/media/video18.webm" type="video/webm">
-      <source data-src="assets/media/video18.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video25.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video25.webm" type="video/webm">
-      <source data-src="assets/media/video25.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image17-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image17-480.webp 480w" type="image/webp">
-        <img alt="jellyfish" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image17.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video10.jpg" preload="none" width="606">
-      <source data-src="assets/media/video10.webm" type="video/webm">
-      <source data-src="assets/media/video10.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video8.jpg" preload="none" width="608">
-      <source data-src="assets/media/video8.webm" type="video/webm">
-      <source data-src="assets/media/video8.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image16-1080.avif 1080w, assets/images/image16-480.avif 480w, assets/images/image16-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image16-1080.webp 1080w, assets/images/image16-480.webp 480w, assets/images/image16-800.webp 800w" type="image/webp">
-        <img alt="jellyfish-clouds" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image16.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image59-1080.avif 1080w, assets/images/image59-800.avif 800w, assets/images/image59-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image59-1080.webp 1080w, assets/images/image59-800.webp 800w, assets/images/image59-480.webp 480w" type="image/webp">
-        <img alt="quantum-feather" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image59.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image67-1080.avif 1080w, assets/images/image67-480.avif 480w, assets/images/image67-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image67-1080.webp 1080w, assets/images/image67-480.webp 480w, assets/images/image67-800.webp 800w" type="image/webp">
-        <img alt="marble-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image67.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image69-1080.avif 1080w, assets/images/image69-480.avif 480w, assets/images/image69-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image69-1080.webp 1080w, assets/images/image69-480.webp 480w, assets/images/image69-800.webp 800w" type="image/webp">
-        <img alt="porcelain-crown-figure" decoding="async" height="1600" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image69.webp" width="900">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image71-1080.avif 1080w, assets/images/image71-480.avif 480w, assets/images/image71-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image71-1080.webp 1080w, assets/images/image71-480.webp 480w, assets/images/image71-800.webp 800w" type="image/webp">
-        <img alt="wizard-of-oz-immersive-stage" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image71.webp" width="1600">
+      <source srcset="assets/images/image58-1080.avif 1080w, assets/images/image58-800.avif 800w, assets/images/image58-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image58-1080.webp 1080w, assets/images/image58-800.webp 800w, assets/images/image58-480.webp 480w" type="image/webp">
+        <img alt="ember-cloud" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image58.webp" width="1080">
      </picture>
     </div>
     <div class="gallery-item">
@@ -851,30 +332,81 @@
      </picture>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image48-1080.avif 576w, assets/images/image48-800.avif 576w, assets/images/image48-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image48-1080.webp 576w, assets/images/image48-800.webp 576w, assets/images/image48-480.webp 480w" type="image/webp">
-        <img alt="arctic-flux" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image48.webp" width="576">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video14.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video14.webm" type="video/webm">
-      <source data-src="assets/media/video14.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video62.jpg" preload="none" width="594">
+      <source data-src="assets/media/video62.webm" type="video/webm">
+      <source data-src="assets/media/video62.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image2-1080.avif 1080w, assets/images/image2-480.avif 480w, assets/images/image2-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image2-1080.webp 1080w, assets/images/image2-480.webp 480w, assets/images/image2-800.webp 800w" type="image/webp">
-        <img alt="live-performance-warehouse" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image2.webp" width="1080">
+      <source srcset="assets/images/image36-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image36-480.webp 480w" type="image/webp">
+        <img alt="squares" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image36.webp" width="608">
      </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video66.jpg" preload="none" width="594">
+      <source data-src="assets/media/video66.webm" type="video/webm">
+      <source data-src="assets/media/video66.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video10.jpg" preload="none" width="606">
+      <source data-src="assets/media/video10.webm" type="video/webm">
+      <source data-src="assets/media/video10.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image59-1080.avif 1080w, assets/images/image59-800.avif 800w, assets/images/image59-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image59-1080.webp 1080w, assets/images/image59-800.webp 800w, assets/images/image59-480.webp 480w" type="image/webp">
+        <img alt="quantum-feather" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image59.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video68.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video68.webm" type="video/webm">
+      <source data-src="assets/media/video68.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image68-1080.avif 1080w, assets/images/image68-480.avif 480w, assets/images/image68-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image68-1080.webp 1080w, assets/images/image68-480.webp 480w, assets/images/image68-800.webp 800w" type="image/webp">
+        <img alt="spiked-floral-study" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image68.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video56.jpg" preload="none" width="606">
+      <source data-src="assets/media/video56.webm" type="video/webm">
+      <source data-src="assets/media/video56.mp4" type="video/mp4">
+     </video>
     </div>
     <div class="gallery-item">
      <picture>
       <source srcset="assets/images/image40-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image40-480.webp 480w" type="image/webp">
         <img alt="tiger-outline" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image40.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image8-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image8-480.webp 480w" type="image/webp">
+        <img alt="explode" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image8.webp" width="612">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video32.jpg" preload="none" width="608">
+      <source data-src="assets/media/video32.webm" type="video/webm">
+      <source data-src="assets/media/video32.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image42-1080.avif 1080w, assets/images/image42-800.avif 800w, assets/images/image42-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image42-1080.webp 1080w, assets/images/image42-800.webp 800w, assets/images/image42-480.webp 480w" type="image/webp">
+        <img alt="crystal-drift" decoding="async" height="1066" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image42.webp" width="1600">
      </picture>
     </div>
     <div class="gallery-item">
@@ -885,47 +417,106 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image1-1080.avif 1080w, assets/images/image1-480.avif 480w, assets/images/image1-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image1-1080.webp 1080w, assets/images/image1-480.webp 480w, assets/images/image1-800.webp 800w" type="image/webp">
-        <img alt="vjing" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image1.webp" width="1080">
+      <source srcset="assets/images/image65-1080.avif 1080w, assets/images/image65-480.avif 480w, assets/images/image65-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image65-1080.webp 1080w, assets/images/image65-480.webp 480w, assets/images/image65-800.webp 800w" type="image/webp">
+        <img alt="lostless-live-performance-wall" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image65.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video2.jpg" preload="none" width="608">
+      <source data-src="assets/media/video2.webm" type="video/webm">
+      <source data-src="assets/media/video2.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video46.jpg" preload="none" width="606">
+      <source data-src="assets/media/video46.webm" type="video/webm">
+      <source data-src="assets/media/video46.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image63-1080.avif 1024w, assets/images/image63-800.avif 800w, assets/images/image63-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image63-1080.webp 1024w, assets/images/image63-800.webp 800w, assets/images/image63-480.webp 480w" type="image/webp">
+        <img alt="velvet-thunder" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image63.webp" width="1024">
      </picture>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image6-1080.avif 1080w, assets/images/image6-480.avif 480w, assets/images/image6-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image6-1080.webp 1080w, assets/images/image6-480.webp 480w, assets/images/image6-800.webp 800w" type="image/webp">
-        <img alt="skull-art" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image6.webp" width="1080">
+      <source srcset="assets/images/image9-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image9-480.webp 480w" type="image/webp">
+        <img alt="martial-arts" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image9.webp" width="609">
      </picture>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image66-1080.avif 1080w, assets/images/image66-480.avif 480w, assets/images/image66-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image66-1080.webp 1080w, assets/images/image66-480.webp 480w, assets/images/image66-800.webp 800w" type="image/webp">
-        <img alt="floral-portrait" decoding="async" height="1920" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image66.webp" width="1080">
+      <source srcset="assets/images/image2-1080.avif 1080w, assets/images/image2-480.avif 480w, assets/images/image2-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image2-1080.webp 1080w, assets/images/image2-480.webp 480w, assets/images/image2-800.webp 800w" type="image/webp">
+        <img alt="live-performance-warehouse" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image2.webp" width="1080">
      </picture>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video16.jpg" preload="none" width="608">
-      <source data-src="assets/media/video16.webm" type="video/webm">
-      <source data-src="assets/media/video16.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image49-1080.avif 704w, assets/images/image49-800.avif 704w, assets/images/image49-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image49-1080.webp 704w, assets/images/image49-800.webp 704w, assets/images/image49-480.webp 480w" type="image/webp">
+        <img alt="magnetic-pulse" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image49.webp" width="704">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video48.jpg" preload="none" width="606">
+      <source data-src="assets/media/video48.webm" type="video/webm">
+      <source data-src="assets/media/video48.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video9.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video9.webm" type="video/webm">
-      <source data-src="assets/media/video9.mp4" type="video/mp4">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video60.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video60.webm" type="video/webm">
+      <source data-src="assets/media/video60.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video3.jpg" preload="none" width="608">
-      <source data-src="assets/media/video3.webm" type="video/webm">
-      <source data-src="assets/media/video3.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image64-1080.avif 1080w, assets/images/image64-480.avif 480w, assets/images/image64-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image64-1080.webp 1080w, assets/images/image64-480.webp 480w, assets/images/image64-800.webp 800w" type="image/webp">
+        <img alt="live-performance-radial" class="lazy-fade" decoding="async" fetchpriority="high" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image64.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video20.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video20.webm" type="video/webm">
+      <source data-src="assets/media/video20.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video27.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video27.webm" type="video/webm">
-      <source data-src="assets/media/video27.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image44-1080.avif 1080w, assets/images/image44-800.avif 800w, assets/images/image44-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image44-1080.webp 1080w, assets/images/image44-800.webp 800w, assets/images/image44-480.webp 480w" type="image/webp">
+        <img alt="nebula-veil" decoding="async" height="902" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image44.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image13-1080.avif 1080w, assets/images/image13-480.avif 480w, assets/images/image13-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image13-1080.webp 1080w, assets/images/image13-480.webp 480w, assets/images/image13-800.webp 800w" type="image/webp">
+        <img alt="shell" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image13.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video28.jpg" preload="none" width="608">
+      <source data-src="assets/media/video28.webm" type="video/webm">
+      <source data-src="assets/media/video28.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video6.jpg" preload="none" width="608">
+      <source data-src="assets/media/video6.webm" type="video/webm">
+      <source data-src="assets/media/video6.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video44.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video44.webm" type="video/webm">
+      <source data-src="assets/media/video44.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -937,9 +528,393 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image53-1080.avif 1080w, assets/images/image53-800.avif 800w, assets/images/image53-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image53-1080.webp 1080w, assets/images/image53-800.webp 800w, assets/images/image53-480.webp 480w" type="image/webp">
-        <img alt="mirror-forest" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image53.webp" width="1280">
+      <source srcset="assets/images/image30-1080.avif 1080w, assets/images/image30-480.avif 480w, assets/images/image30-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image30-1080.webp 1080w, assets/images/image30-480.webp 480w, assets/images/image30-800.webp 800w" type="image/webp">
+        <img alt="solar" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image30.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image6-1080.avif 1080w, assets/images/image6-480.avif 480w, assets/images/image6-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image6-1080.webp 1080w, assets/images/image6-480.webp 480w, assets/images/image6-800.webp 800w" type="image/webp">
+        <img alt="skull-art" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image6.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image3-480.avif 480w, assets/images/image3-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image3-480.webp 480w, assets/images/image3-800.webp 800w" type="image/webp">
+        <img alt="livemusic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image3.webp" width="914">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video24.jpg" preload="none" width="608">
+      <source data-src="assets/media/video24.webm" type="video/webm">
+      <source data-src="assets/media/video24.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image55-1080.avif 1080w, assets/images/image55-800.avif 800w, assets/images/image55-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image55-1080.webp 1080w, assets/images/image55-800.webp 800w, assets/images/image55-480.webp 480w" type="image/webp">
+        <img alt="stellar-storm" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image55.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image18-1080.avif 1080w, assets/images/image18-480.avif 480w, assets/images/image18-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image18-1080.webp 1080w, assets/images/image18-480.webp 480w, assets/images/image18-800.webp 800w" type="image/webp">
+        <img alt="jungle" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image18.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image39-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image39-480.webp 480w" type="image/webp">
+        <img alt="snake-green" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image39.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video16.jpg" preload="none" width="608">
+      <source data-src="assets/media/video16.webm" type="video/webm">
+      <source data-src="assets/media/video16.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video34.jpg" preload="none" width="608">
+      <source data-src="assets/media/video34.webm" type="video/webm">
+      <source data-src="assets/media/video34.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image66-1080.avif 1080w, assets/images/image66-480.avif 480w, assets/images/image66-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image66-1080.webp 1080w, assets/images/image66-480.webp 480w, assets/images/image66-800.webp 800w" type="image/webp">
+        <img alt="floral-portrait" decoding="async" height="1920" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image66.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video12.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video12.webm" type="video/webm">
+      <source data-src="assets/media/video12.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video58.jpg" preload="none" width="606">
+      <source data-src="assets/media/video58.webm" type="video/webm">
+      <source data-src="assets/media/video58.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image17-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image17-480.webp 480w" type="image/webp">
+        <img alt="jellyfish" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image17.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1928" loop muted playsinline poster="assets/media/video31.jpg" preload="none" width="1088">
+      <source data-src="assets/media/video31.webm" type="video/webm">
+      <source data-src="assets/media/video31.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video11.jpg" preload="none" width="608">
+      <source data-src="assets/media/video11.webm" type="video/webm">
+      <source data-src="assets/media/video11.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image1-1080.avif 1080w, assets/images/image1-480.avif 480w, assets/images/image1-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image1-1080.webp 1080w, assets/images/image1-480.webp 480w, assets/images/image1-800.webp 800w" type="image/webp">
+        <img alt="vjing" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image1.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image61-1080.avif 1080w, assets/images/image61-800.avif 800w, assets/images/image61-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image61-1080.webp 1080w, assets/images/image61-800.webp 800w, assets/images/image61-480.webp 480w" type="image/webp">
+        <img alt="petal-maelstrom" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image61.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image32-1080.avif 1080w, assets/images/image32-480.avif 480w, assets/images/image32-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image32-1080.webp 1080w, assets/images/image32-480.webp 480w, assets/images/image32-800.webp 800w" type="image/webp">
+        <img alt="poison" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image32.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image69-1080.avif 1080w, assets/images/image69-480.avif 480w, assets/images/image69-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image69-1080.webp 1080w, assets/images/image69-480.webp 480w, assets/images/image69-800.webp 800w" type="image/webp">
+        <img alt="porcelain-crown-figure" decoding="async" height="1600" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image69.webp" width="900">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video15.jpg" preload="none" width="608">
+      <source data-src="assets/media/video15.webm" type="video/webm">
+      <source data-src="assets/media/video15.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image16-1080.avif 1080w, assets/images/image16-480.avif 480w, assets/images/image16-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image16-1080.webp 1080w, assets/images/image16-480.webp 480w, assets/images/image16-800.webp 800w" type="image/webp">
+        <img alt="jellyfish-clouds" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image16.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video40.jpg" preload="none" width="608">
+      <source data-src="assets/media/video40.webm" type="video/webm">
+      <source data-src="assets/media/video40.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video29.jpg" preload="none" width="810">
+      <source data-src="assets/media/video29.webm" type="video/webm">
+      <source data-src="assets/media/video29.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video50.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video50.webm" type="video/webm">
+      <source data-src="assets/media/video50.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video76.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video76.webm" type="video/webm">
+      <source data-src="assets/media/video76.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video73.jpg" preload="none" width="612">
+      <source data-src="assets/media/video73.webm" type="video/webm">
+      <source data-src="assets/media/video73.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image4-480.avif 480w, assets/images/image4-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image4-480.webp 480w, assets/images/image4-800.webp 800w" type="image/webp">
+        <img alt="vj-live" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image4.webp" width="810">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image67-1080.avif 1080w, assets/images/image67-480.avif 480w, assets/images/image67-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image67-1080.webp 1080w, assets/images/image67-480.webp 480w, assets/images/image67-800.webp 800w" type="image/webp">
+        <img alt="marble-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image67.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video8.jpg" preload="none" width="608">
+      <source data-src="assets/media/video8.webm" type="video/webm">
+      <source data-src="assets/media/video8.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image22-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image22-480.webp 480w" type="image/webp">
+        <img alt="technicolor" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image22.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video7.jpg" preload="none" width="608">
+      <source data-src="assets/media/video7.webm" type="video/webm">
+      <source data-src="assets/media/video7.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video64.jpg" preload="none" width="594">
+      <source data-src="assets/media/video64.webm" type="video/webm">
+      <source data-src="assets/media/video64.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image48-1080.avif 576w, assets/images/image48-800.avif 576w, assets/images/image48-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image48-1080.webp 576w, assets/images/image48-800.webp 576w, assets/images/image48-480.webp 480w" type="image/webp">
+        <img alt="arctic-flux" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image48.webp" width="576">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video74.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video74.webm" type="video/webm">
+      <source data-src="assets/media/video74.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video19.jpg" preload="none" width="608">
+      <source data-src="assets/media/video19.webm" type="video/webm">
+      <source data-src="assets/media/video19.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image51-1080.avif 704w, assets/images/image51-800.avif 704w, assets/images/image51-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image51-1080.webp 704w, assets/images/image51-800.webp 704w, assets/images/image51-480.webp 480w" type="image/webp">
+        <img alt="cosmic-orchid" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image51.webp" width="704">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image35-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image35-480.webp 480w" type="image/webp">
+        <img alt="eye-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image35.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image54-1080.avif 1080w, assets/images/image54-800.avif 800w, assets/images/image54-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image54-1080.webp 1080w, assets/images/image54-800.webp 800w, assets/images/image54-480.webp 480w" type="image/webp">
+        <img alt="skyline-glitch" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image54.webp" width="1280">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video70.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video70.webm" type="video/webm">
+      <source data-src="assets/media/video70.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image29-1080.avif 1080w, assets/images/image29-480.avif 480w, assets/images/image29-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image29-1080.webp 1080w, assets/images/image29-480.webp 480w, assets/images/image29-800.webp 800w" type="image/webp">
+        <img alt="plants" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image29.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image10-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image10-480.webp 480w" type="image/webp">
+        <img alt="landscape" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image10.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video54.jpg" preload="none" width="606">
+      <source data-src="assets/media/video54.webm" type="video/webm">
+      <source data-src="assets/media/video54.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image45-1080.avif 576w, assets/images/image45-800.avif 576w, assets/images/image45-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image45-1080.webp 576w, assets/images/image45-800.webp 576w, assets/images/image45-480.webp 480w" type="image/webp">
+        <img alt="holographic-wave" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image45.webp" width="576">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video18.jpg" preload="none" width="608">
+      <source data-src="assets/media/video18.webm" type="video/webm">
+      <source data-src="assets/media/video18.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video17.jpg" preload="none" width="608">
+      <source data-src="assets/media/video17.webm" type="video/webm">
+      <source data-src="assets/media/video17.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image28-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image28-480.webp 480w" type="image/webp">
+        <img alt="villan" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image28.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image15-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image15-480.webp 480w" type="image/webp">
+        <img alt="necrosis" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image15.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image26-1080.avif 1080w, assets/images/image26-480.avif 480w, assets/images/image26-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image26-1080.webp 1080w, assets/images/image26-480.webp 480w, assets/images/image26-800.webp 800w" type="image/webp">
+        <img alt="ghost-in-the-shell" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image26.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image24-1080.avif 1080w, assets/images/image24-480.avif 480w, assets/images/image24-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image24-1080.webp 1080w, assets/images/image24-480.webp 480w, assets/images/image24-800.webp 800w" type="image/webp">
+        <img alt="slime-installation" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image24.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video4.jpg" preload="none" width="608">
+      <source data-src="assets/media/video4.webm" type="video/webm">
+      <source data-src="assets/media/video4.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video30.jpg" preload="none" width="608">
+      <source data-src="assets/media/video30.webm" type="video/webm">
+      <source data-src="assets/media/video30.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video52.jpg" preload="none" width="606">
+      <source data-src="assets/media/video52.webm" type="video/webm">
+      <source data-src="assets/media/video52.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video13.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video13.webm" type="video/webm">
+      <source data-src="assets/media/video13.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video3.jpg" preload="none" width="608">
+      <source data-src="assets/media/video3.webm" type="video/webm">
+      <source data-src="assets/media/video3.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image20-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image20-480.webp 480w" type="image/webp">
+        <img alt="octopus-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image20.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image71-1080.avif 1080w, assets/images/image71-480.avif 480w, assets/images/image71-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image71-1080.webp 1080w, assets/images/image71-480.webp 480w, assets/images/image71-800.webp 800w" type="image/webp">
+        <img alt="wizard-of-oz-immersive-stage" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image71.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image12-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image12-480.webp 480w" type="image/webp">
+        <img alt="surreal" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image12.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video25.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video25.webm" type="video/webm">
+      <source data-src="assets/media/video25.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="612" loop muted playsinline poster="assets/media/video71.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video71.webm" type="video/webm">
+      <source data-src="assets/media/video71.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image60-1080.avif 1080w, assets/images/image60-800.avif 800w, assets/images/image60-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image60-1080.webp 1080w, assets/images/image60-800.webp 800w, assets/images/image60-480.webp 480w" type="image/webp">
+        <img alt="nova-swarm" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image60.webp" width="1080">
      </picture>
     </div>
     <div class="gallery-item">
@@ -947,6 +922,31 @@
       <source srcset="assets/images/image25-480.avif 480w" type="image/avif">
        <source srcset="assets/images/image25-480.webp 480w" type="image/webp">
         <img alt="tiger" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image25.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video27.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video27.webm" type="video/webm">
+      <source data-src="assets/media/video27.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video1.jpg" preload="none" width="608">
+      <source data-src="assets/media/video1.webm" type="video/webm">
+      <source data-src="assets/media/video1.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video9.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video9.webm" type="video/webm">
+      <source data-src="assets/media/video9.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image27-1080.avif 1080w, assets/images/image27-480.avif 480w, assets/images/image27-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image27-1080.webp 1080w, assets/images/image27-480.webp 480w, assets/images/image27-800.webp 800w" type="image/webp">
+        <img alt="liminal-space" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image27.webp" width="1080">
      </picture>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -177,16 +177,102 @@
    </section>
   <section class="gallery-grid grid">
     <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video14.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video14.webm" type="video/webm">
-      <source data-src="assets/media/video14.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image61-1080.avif 1080w, assets/images/image61-800.avif 800w, assets/images/image61-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image61-1080.webp 1080w, assets/images/image61-800.webp 800w, assets/images/image61-480.webp 480w" type="image/webp">
+        <img alt="petal-maelstrom" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image61.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video30.jpg" preload="none" width="608">
+      <source data-src="assets/media/video30.webm" type="video/webm">
+      <source data-src="assets/media/video30.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video74.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video74.webm" type="video/webm">
+      <source data-src="assets/media/video74.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video62.jpg" preload="none" width="594">
+      <source data-src="assets/media/video62.webm" type="video/webm">
+      <source data-src="assets/media/video62.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image57-1080.avif 1080w, assets/images/image57-800.avif 800w, assets/images/image57-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image57-1080.webp 1080w, assets/images/image57-800.webp 800w, assets/images/image57-480.webp 480w" type="image/webp">
-        <img alt="spiral-halo" decoding="async" height="720" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image57.webp" width="1280">
+      <source srcset="assets/images/image67-1080.avif 1080w, assets/images/image67-480.avif 480w, assets/images/image67-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image67-1080.webp 1080w, assets/images/image67-480.webp 480w, assets/images/image67-800.webp 800w" type="image/webp">
+        <img alt="marble-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image67.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image19-1080.avif 1080w, assets/images/image19-480.avif 480w, assets/images/image19-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image19-1080.webp 1080w, assets/images/image19-480.webp 480w, assets/images/image19-800.webp 800w" type="image/webp">
+        <img alt="spectre" decoding="async" height="606" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image19.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image8-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image8-480.webp 480w" type="image/webp">
+        <img alt="explode" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image8.webp" width="612">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image9-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image9-480.webp 480w" type="image/webp">
+        <img alt="martial-arts" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image9.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image13-1080.avif 1080w, assets/images/image13-480.avif 480w, assets/images/image13-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image13-1080.webp 1080w, assets/images/image13-480.webp 480w, assets/images/image13-800.webp 800w" type="image/webp">
+        <img alt="shell" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image13.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image18-1080.avif 1080w, assets/images/image18-480.avif 480w, assets/images/image18-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image18-1080.webp 1080w, assets/images/image18-480.webp 480w, assets/images/image18-800.webp 800w" type="image/webp">
+        <img alt="jungle" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image18.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video10.jpg" preload="none" width="606">
+      <source data-src="assets/media/video10.webm" type="video/webm">
+      <source data-src="assets/media/video10.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video32.jpg" preload="none" width="608">
+      <source data-src="assets/media/video32.webm" type="video/webm">
+      <source data-src="assets/media/video32.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video16.jpg" preload="none" width="608">
+      <source data-src="assets/media/video16.webm" type="video/webm">
+      <source data-src="assets/media/video16.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image15-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image15-480.webp 480w" type="image/webp">
+        <img alt="necrosis" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image15.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image22-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image22-480.webp 480w" type="image/webp">
+        <img alt="technicolor" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image22.webp" width="608">
      </picture>
     </div>
     <div class="gallery-item">
@@ -196,49 +282,56 @@
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video33.jpg" preload="none" width="608">
-      <source data-src="assets/media/video33.webm" type="video/webm">
-      <source data-src="assets/media/video33.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image17-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image17-480.webp 480w" type="image/webp">
+        <img alt="jellyfish" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image17.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video70.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video70.webm" type="video/webm">
+      <source data-src="assets/media/video70.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video75.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video75.webm" type="video/webm">
-      <source data-src="assets/media/video75.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video26.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video26.webm" type="video/webm">
-      <source data-src="assets/media/video26.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video48.jpg" preload="none" width="606">
+      <source data-src="assets/media/video48.webm" type="video/webm">
+      <source data-src="assets/media/video48.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image11-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image11-480.webp 480w" type="image/webp">
-        <img alt="yellow-devil" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image11.webp" width="609">
+      <source srcset="assets/images/image62-1080.avif 1080w, assets/images/image62-800.avif 800w, assets/images/image62-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image62-1080.webp 1080w, assets/images/image62-800.webp 800w, assets/images/image62-480.webp 480w" type="image/webp">
+        <img alt="radiant-reef" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image62.webp" width="1080">
      </picture>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image47-1080.avif 1024w, assets/images/image47-800.avif 800w, assets/images/image47-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image47-1080.webp 1024w, assets/images/image47-800.webp 800w, assets/images/image47-480.webp 480w" type="image/webp">
-        <img alt="liquid-mesh" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image47.webp" width="1024">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image53-1080.avif 1080w, assets/images/image53-800.avif 800w, assets/images/image53-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image53-1080.webp 1080w, assets/images/image53-800.webp 800w, assets/images/image53-480.webp 480w" type="image/webp">
-        <img alt="mirror-forest" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image53.webp" width="1280">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video5.jpg" preload="none" width="612">
-      <source data-src="assets/media/video5.webm" type="video/webm">
-      <source data-src="assets/media/video5.mp4" type="video/mp4">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video50.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video50.webm" type="video/webm">
+      <source data-src="assets/media/video50.mp4" type="video/mp4">
      </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1928" loop muted playsinline poster="assets/media/video31.jpg" preload="none" width="1088">
+      <source data-src="assets/media/video31.webm" type="video/webm">
+      <source data-src="assets/media/video31.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image30-1080.avif 1080w, assets/images/image30-480.avif 480w, assets/images/image30-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image30-1080.webp 1080w, assets/images/image30-480.webp 480w, assets/images/image30-800.webp 800w" type="image/webp">
+        <img alt="solar" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image30.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image42-1080.avif 1080w, assets/images/image42-800.avif 800w, assets/images/image42-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image42-1080.webp 1080w, assets/images/image42-800.webp 800w, assets/images/image42-480.webp 480w" type="image/webp">
+        <img alt="crystal-drift" decoding="async" height="1066" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image42.webp" width="1600">
+     </picture>
     </div>
     <div class="gallery-item">
      <picture>
@@ -254,119 +347,15 @@
      </video>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image38-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image38-480.webp 480w" type="image/webp">
-        <img alt="ghost" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image38.webp" width="606">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video36.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video36.webm" type="video/webm">
-      <source data-src="assets/media/video36.mp4" type="video/mp4">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video44.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video44.webm" type="video/webm">
+      <source data-src="assets/media/video44.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video72.jpg" preload="none" width="612">
-      <source data-src="assets/media/video72.webm" type="video/webm">
-      <source data-src="assets/media/video72.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image23-1080.avif 1080w, assets/images/image23-480.avif 480w, assets/images/image23-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image23-1080.webp 1080w, assets/images/image23-480.webp 480w, assets/images/image23-800.webp 800w" type="image/webp">
-        <img alt="lotus" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image23.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video38.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video38.webm" type="video/webm">
-      <source data-src="assets/media/video38.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image62-1080.avif 1080w, assets/images/image62-800.avif 800w, assets/images/image62-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image62-1080.webp 1080w, assets/images/image62-800.webp 800w, assets/images/image62-480.webp 480w" type="image/webp">
-        <img alt="radiant-reef" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image62.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image5-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image5-480.webp 480w" type="image/webp">
-        <img alt="installation" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image5.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video21.jpg" preload="none" width="610">
-      <source data-src="assets/media/video21.webm" type="video/webm">
-      <source data-src="assets/media/video21.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video22.jpg" preload="none" width="810">
-      <source data-src="assets/media/video22.webm" type="video/webm">
-      <source data-src="assets/media/video22.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video23.jpg" preload="none" width="608">
-      <source data-src="assets/media/video23.webm" type="video/webm">
-      <source data-src="assets/media/video23.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image58-1080.avif 1080w, assets/images/image58-800.avif 800w, assets/images/image58-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image58-1080.webp 1080w, assets/images/image58-800.webp 800w, assets/images/image58-480.webp 480w" type="image/webp">
-        <img alt="ember-cloud" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image58.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image19-1080.avif 1080w, assets/images/image19-480.avif 480w, assets/images/image19-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image19-1080.webp 1080w, assets/images/image19-480.webp 480w, assets/images/image19-800.webp 800w" type="image/webp">
-        <img alt="spectre" decoding="async" height="606" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image19.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video62.jpg" preload="none" width="594">
-      <source data-src="assets/media/video62.webm" type="video/webm">
-      <source data-src="assets/media/video62.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image36-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image36-480.webp 480w" type="image/webp">
-        <img alt="squares" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image36.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video66.jpg" preload="none" width="594">
-      <source data-src="assets/media/video66.webm" type="video/webm">
-      <source data-src="assets/media/video66.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video10.jpg" preload="none" width="606">
-      <source data-src="assets/media/video10.webm" type="video/webm">
-      <source data-src="assets/media/video10.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image59-1080.avif 1080w, assets/images/image59-800.avif 800w, assets/images/image59-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image59-1080.webp 1080w, assets/images/image59-800.webp 800w, assets/images/image59-480.webp 480w" type="image/webp">
-        <img alt="quantum-feather" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image59.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video68.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video68.webm" type="video/webm">
-      <source data-src="assets/media/video68.mp4" type="video/mp4">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video9.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video9.webm" type="video/webm">
+      <source data-src="assets/media/video9.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -377,355 +366,27 @@
      </picture>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video56.jpg" preload="none" width="606">
-      <source data-src="assets/media/video56.webm" type="video/webm">
-      <source data-src="assets/media/video56.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image40-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image40-480.webp 480w" type="image/webp">
-        <img alt="tiger-outline" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image40.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image8-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image8-480.webp 480w" type="image/webp">
-        <img alt="explode" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image8.webp" width="612">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video32.jpg" preload="none" width="608">
-      <source data-src="assets/media/video32.webm" type="video/webm">
-      <source data-src="assets/media/video32.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image42-1080.avif 1080w, assets/images/image42-800.avif 800w, assets/images/image42-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image42-1080.webp 1080w, assets/images/image42-800.webp 800w, assets/images/image42-480.webp 480w" type="image/webp">
-        <img alt="crystal-drift" decoding="async" height="1066" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image42.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video35.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video35.webm" type="video/webm">
-      <source data-src="assets/media/video35.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image65-1080.avif 1080w, assets/images/image65-480.avif 480w, assets/images/image65-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image65-1080.webp 1080w, assets/images/image65-480.webp 480w, assets/images/image65-800.webp 800w" type="image/webp">
-        <img alt="lostless-live-performance-wall" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image65.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video2.jpg" preload="none" width="608">
-      <source data-src="assets/media/video2.webm" type="video/webm">
-      <source data-src="assets/media/video2.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video46.jpg" preload="none" width="606">
-      <source data-src="assets/media/video46.webm" type="video/webm">
-      <source data-src="assets/media/video46.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image63-1080.avif 1024w, assets/images/image63-800.avif 800w, assets/images/image63-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image63-1080.webp 1024w, assets/images/image63-800.webp 800w, assets/images/image63-480.webp 480w" type="image/webp">
-        <img alt="velvet-thunder" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image63.webp" width="1024">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image9-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image9-480.webp 480w" type="image/webp">
-        <img alt="martial-arts" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image9.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image2-1080.avif 1080w, assets/images/image2-480.avif 480w, assets/images/image2-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image2-1080.webp 1080w, assets/images/image2-480.webp 480w, assets/images/image2-800.webp 800w" type="image/webp">
-        <img alt="live-performance-warehouse" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image2.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image49-1080.avif 704w, assets/images/image49-800.avif 704w, assets/images/image49-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image49-1080.webp 704w, assets/images/image49-800.webp 704w, assets/images/image49-480.webp 480w" type="image/webp">
-        <img alt="magnetic-pulse" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image49.webp" width="704">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video48.jpg" preload="none" width="606">
-      <source data-src="assets/media/video48.webm" type="video/webm">
-      <source data-src="assets/media/video48.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video60.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video60.webm" type="video/webm">
-      <source data-src="assets/media/video60.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image64-1080.avif 1080w, assets/images/image64-480.avif 480w, assets/images/image64-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image64-1080.webp 1080w, assets/images/image64-480.webp 480w, assets/images/image64-800.webp 800w" type="image/webp">
-        <img alt="live-performance-radial" class="lazy-fade" decoding="async" fetchpriority="high" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image64.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video20.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video20.webm" type="video/webm">
-      <source data-src="assets/media/video20.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image44-1080.avif 1080w, assets/images/image44-800.avif 800w, assets/images/image44-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image44-1080.webp 1080w, assets/images/image44-800.webp 800w, assets/images/image44-480.webp 480w" type="image/webp">
-        <img alt="nebula-veil" decoding="async" height="902" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image44.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image13-1080.avif 1080w, assets/images/image13-480.avif 480w, assets/images/image13-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image13-1080.webp 1080w, assets/images/image13-480.webp 480w, assets/images/image13-800.webp 800w" type="image/webp">
-        <img alt="shell" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image13.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video28.jpg" preload="none" width="608">
-      <source data-src="assets/media/video28.webm" type="video/webm">
-      <source data-src="assets/media/video28.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video6.jpg" preload="none" width="608">
-      <source data-src="assets/media/video6.webm" type="video/webm">
-      <source data-src="assets/media/video6.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video44.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video44.webm" type="video/webm">
-      <source data-src="assets/media/video44.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image43-1080.avif 1080w, assets/images/image43-800.avif 800w, assets/images/image43-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image43-1080.webp 1080w, assets/images/image43-800.webp 800w, assets/images/image43-480.webp 480w" type="image/webp">
-        <img alt="tunnel-flare" decoding="async" height="1928" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image43.webp" width="1088">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image30-1080.avif 1080w, assets/images/image30-480.avif 480w, assets/images/image30-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image30-1080.webp 1080w, assets/images/image30-480.webp 480w, assets/images/image30-800.webp 800w" type="image/webp">
-        <img alt="solar" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image30.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image6-1080.avif 1080w, assets/images/image6-480.avif 480w, assets/images/image6-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image6-1080.webp 1080w, assets/images/image6-480.webp 480w, assets/images/image6-800.webp 800w" type="image/webp">
-        <img alt="skull-art" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image6.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image3-480.avif 480w, assets/images/image3-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image3-480.webp 480w, assets/images/image3-800.webp 800w" type="image/webp">
-        <img alt="livemusic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image3.webp" width="914">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video24.jpg" preload="none" width="608">
-      <source data-src="assets/media/video24.webm" type="video/webm">
-      <source data-src="assets/media/video24.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image55-1080.avif 1080w, assets/images/image55-800.avif 800w, assets/images/image55-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image55-1080.webp 1080w, assets/images/image55-800.webp 800w, assets/images/image55-480.webp 480w" type="image/webp">
-        <img alt="stellar-storm" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image55.webp" width="1600">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image18-1080.avif 1080w, assets/images/image18-480.avif 480w, assets/images/image18-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image18-1080.webp 1080w, assets/images/image18-480.webp 480w, assets/images/image18-800.webp 800w" type="image/webp">
-        <img alt="jungle" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image18.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image39-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image39-480.webp 480w" type="image/webp">
-        <img alt="snake-green" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image39.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video16.jpg" preload="none" width="608">
-      <source data-src="assets/media/video16.webm" type="video/webm">
-      <source data-src="assets/media/video16.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video34.jpg" preload="none" width="608">
-      <source data-src="assets/media/video34.webm" type="video/webm">
-      <source data-src="assets/media/video34.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image66-1080.avif 1080w, assets/images/image66-480.avif 480w, assets/images/image66-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image66-1080.webp 1080w, assets/images/image66-480.webp 480w, assets/images/image66-800.webp 800w" type="image/webp">
-        <img alt="floral-portrait" decoding="async" height="1920" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image66.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video12.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video12.webm" type="video/webm">
-      <source data-src="assets/media/video12.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video58.jpg" preload="none" width="606">
-      <source data-src="assets/media/video58.webm" type="video/webm">
-      <source data-src="assets/media/video58.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image17-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image17-480.webp 480w" type="image/webp">
-        <img alt="jellyfish" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image17.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1928" loop muted playsinline poster="assets/media/video31.jpg" preload="none" width="1088">
-      <source data-src="assets/media/video31.webm" type="video/webm">
-      <source data-src="assets/media/video31.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video11.jpg" preload="none" width="608">
-      <source data-src="assets/media/video11.webm" type="video/webm">
-      <source data-src="assets/media/video11.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image1-1080.avif 1080w, assets/images/image1-480.avif 480w, assets/images/image1-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image1-1080.webp 1080w, assets/images/image1-480.webp 480w, assets/images/image1-800.webp 800w" type="image/webp">
-        <img alt="vjing" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image1.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image61-1080.avif 1080w, assets/images/image61-800.avif 800w, assets/images/image61-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image61-1080.webp 1080w, assets/images/image61-800.webp 800w, assets/images/image61-480.webp 480w" type="image/webp">
-        <img alt="petal-maelstrom" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image61.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image32-1080.avif 1080w, assets/images/image32-480.avif 480w, assets/images/image32-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image32-1080.webp 1080w, assets/images/image32-480.webp 480w, assets/images/image32-800.webp 800w" type="image/webp">
-        <img alt="poison" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image32.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image69-1080.avif 1080w, assets/images/image69-480.avif 480w, assets/images/image69-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image69-1080.webp 1080w, assets/images/image69-480.webp 480w, assets/images/image69-800.webp 800w" type="image/webp">
-        <img alt="porcelain-crown-figure" decoding="async" height="1600" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image69.webp" width="900">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video15.jpg" preload="none" width="608">
-      <source data-src="assets/media/video15.webm" type="video/webm">
-      <source data-src="assets/media/video15.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image16-1080.avif 1080w, assets/images/image16-480.avif 480w, assets/images/image16-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image16-1080.webp 1080w, assets/images/image16-480.webp 480w, assets/images/image16-800.webp 800w" type="image/webp">
-        <img alt="jellyfish-clouds" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image16.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video40.jpg" preload="none" width="608">
-      <source data-src="assets/media/video40.webm" type="video/webm">
-      <source data-src="assets/media/video40.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video29.jpg" preload="none" width="810">
-      <source data-src="assets/media/video29.webm" type="video/webm">
-      <source data-src="assets/media/video29.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video50.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video50.webm" type="video/webm">
-      <source data-src="assets/media/video50.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video76.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video76.webm" type="video/webm">
-      <source data-src="assets/media/video76.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video73.jpg" preload="none" width="612">
-      <source data-src="assets/media/video73.webm" type="video/webm">
-      <source data-src="assets/media/video73.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image4-480.avif 480w, assets/images/image4-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image4-480.webp 480w, assets/images/image4-800.webp 800w" type="image/webp">
-        <img alt="vj-live" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image4.webp" width="810">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image67-1080.avif 1080w, assets/images/image67-480.avif 480w, assets/images/image67-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image67-1080.webp 1080w, assets/images/image67-480.webp 480w, assets/images/image67-800.webp 800w" type="image/webp">
-        <img alt="marble-portrait" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image67.webp" width="1080">
-     </picture>
-    </div>
-    <div class="gallery-item">
      <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video8.jpg" preload="none" width="608">
       <source data-src="assets/media/video8.webm" type="video/webm">
       <source data-src="assets/media/video8.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image22-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image22-480.webp 480w" type="image/webp">
-        <img alt="technicolor" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image22.webp" width="608">
-     </picture>
+     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video26.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video26.webm" type="video/webm">
+      <source data-src="assets/media/video26.mp4" type="video/mp4">
+     </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video7.jpg" preload="none" width="608">
-      <source data-src="assets/media/video7.webm" type="video/webm">
-      <source data-src="assets/media/video7.mp4" type="video/mp4">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video36.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video36.webm" type="video/webm">
+      <source data-src="assets/media/video36.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video54.jpg" preload="none" width="606">
+      <source data-src="assets/media/video54.webm" type="video/webm">
+      <source data-src="assets/media/video54.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -735,49 +396,9 @@
      </video>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image48-1080.avif 576w, assets/images/image48-800.avif 576w, assets/images/image48-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image48-1080.webp 576w, assets/images/image48-800.webp 576w, assets/images/image48-480.webp 480w" type="image/webp">
-        <img alt="arctic-flux" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image48.webp" width="576">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video74.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video74.webm" type="video/webm">
-      <source data-src="assets/media/video74.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video19.jpg" preload="none" width="608">
-      <source data-src="assets/media/video19.webm" type="video/webm">
-      <source data-src="assets/media/video19.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image51-1080.avif 704w, assets/images/image51-800.avif 704w, assets/images/image51-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image51-1080.webp 704w, assets/images/image51-800.webp 704w, assets/images/image51-480.webp 480w" type="image/webp">
-        <img alt="cosmic-orchid" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image51.webp" width="704">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image35-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image35-480.webp 480w" type="image/webp">
-        <img alt="eye-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image35.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image54-1080.avif 1080w, assets/images/image54-800.avif 800w, assets/images/image54-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image54-1080.webp 1080w, assets/images/image54-800.webp 800w, assets/images/image54-480.webp 480w" type="image/webp">
-        <img alt="skyline-glitch" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image54.webp" width="1280">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video70.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video70.webm" type="video/webm">
-      <source data-src="assets/media/video70.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video15.jpg" preload="none" width="608">
+      <source data-src="assets/media/video15.webm" type="video/webm">
+      <source data-src="assets/media/video15.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -789,48 +410,23 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image10-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image10-480.webp 480w" type="image/webp">
-        <img alt="landscape" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image10.webp" width="609">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video54.jpg" preload="none" width="606">
-      <source data-src="assets/media/video54.webm" type="video/webm">
-      <source data-src="assets/media/video54.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image45-1080.avif 576w, assets/images/image45-800.avif 576w, assets/images/image45-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image45-1080.webp 576w, assets/images/image45-800.webp 576w, assets/images/image45-480.webp 480w" type="image/webp">
-        <img alt="holographic-wave" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image45.webp" width="576">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video18.jpg" preload="none" width="608">
-      <source data-src="assets/media/video18.webm" type="video/webm">
-      <source data-src="assets/media/video18.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video17.jpg" preload="none" width="608">
-      <source data-src="assets/media/video17.webm" type="video/webm">
-      <source data-src="assets/media/video17.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image28-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image28-480.webp 480w" type="image/webp">
-        <img alt="villan" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image28.webp" width="609">
+      <source srcset="assets/images/image4-480.avif 480w, assets/images/image4-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image4-480.webp 480w, assets/images/image4-800.webp 800w" type="image/webp">
+        <img alt="vj-live" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image4.webp" width="810">
      </picture>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image15-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image15-480.webp 480w" type="image/webp">
-        <img alt="necrosis" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image15.webp" width="609">
+      <source srcset="assets/images/image51-1080.avif 704w, assets/images/image51-800.avif 704w, assets/images/image51-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image51-1080.webp 704w, assets/images/image51-800.webp 704w, assets/images/image51-480.webp 480w" type="image/webp">
+        <img alt="cosmic-orchid" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image51.webp" width="704">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image12-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image12-480.webp 480w" type="image/webp">
+        <img alt="surreal" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image12.webp" width="609">
      </picture>
     </div>
     <div class="gallery-item">
@@ -842,21 +438,114 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image24-1080.avif 1080w, assets/images/image24-480.avif 480w, assets/images/image24-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image24-1080.webp 1080w, assets/images/image24-480.webp 480w, assets/images/image24-800.webp 800w" type="image/webp">
-        <img alt="slime-installation" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image24.webp" width="1080">
+      <source srcset="assets/images/image71-1080.avif 1080w, assets/images/image71-480.avif 480w, assets/images/image71-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image71-1080.webp 1080w, assets/images/image71-480.webp 480w, assets/images/image71-800.webp 800w" type="image/webp">
+        <img alt="wizard-of-oz-immersive-stage" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image71.webp" width="1600">
      </picture>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video4.jpg" preload="none" width="608">
-      <source data-src="assets/media/video4.webm" type="video/webm">
-      <source data-src="assets/media/video4.mp4" type="video/mp4">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video14.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video14.webm" type="video/webm">
+      <source data-src="assets/media/video14.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video30.jpg" preload="none" width="608">
-      <source data-src="assets/media/video30.webm" type="video/webm">
-      <source data-src="assets/media/video30.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image11-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image11-480.webp 480w" type="image/webp">
+        <img alt="yellow-devil" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image11.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image1-1080.avif 1080w, assets/images/image1-480.avif 480w, assets/images/image1-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image1-1080.webp 1080w, assets/images/image1-480.webp 480w, assets/images/image1-800.webp 800w" type="image/webp">
+        <img alt="vjing" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image1.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image53-1080.avif 1080w, assets/images/image53-800.avif 800w, assets/images/image53-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image53-1080.webp 1080w, assets/images/image53-800.webp 800w, assets/images/image53-480.webp 480w" type="image/webp">
+        <img alt="mirror-forest" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image53.webp" width="1280">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video33.jpg" preload="none" width="608">
+      <source data-src="assets/media/video33.webm" type="video/webm">
+      <source data-src="assets/media/video33.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video2.jpg" preload="none" width="608">
+      <source data-src="assets/media/video2.webm" type="video/webm">
+      <source data-src="assets/media/video2.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image10-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image10-480.webp 480w" type="image/webp">
+        <img alt="landscape" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image10.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image45-1080.avif 576w, assets/images/image45-800.avif 576w, assets/images/image45-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image45-1080.webp 576w, assets/images/image45-800.webp 576w, assets/images/image45-480.webp 480w" type="image/webp">
+        <img alt="holographic-wave" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image45.webp" width="576">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="594" loop muted playsinline poster="assets/media/video68.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video68.webm" type="video/webm">
+      <source data-src="assets/media/video68.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video72.jpg" preload="none" width="612">
+      <source data-src="assets/media/video72.webm" type="video/webm">
+      <source data-src="assets/media/video72.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image35-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image35-480.webp 480w" type="image/webp">
+        <img alt="eye-texture" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image35.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image28-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image28-480.webp 480w" type="image/webp">
+        <img alt="villan" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image28.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image47-1080.avif 1024w, assets/images/image47-800.avif 800w, assets/images/image47-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image47-1080.webp 1024w, assets/images/image47-800.webp 800w, assets/images/image47-480.webp 480w" type="image/webp">
+        <img alt="liquid-mesh" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image47.webp" width="1024">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video19.jpg" preload="none" width="608">
+      <source data-src="assets/media/video19.webm" type="video/webm">
+      <source data-src="assets/media/video19.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image23-1080.avif 1080w, assets/images/image23-480.avif 480w, assets/images/image23-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image23-1080.webp 1080w, assets/images/image23-480.webp 480w, assets/images/image23-800.webp 800w" type="image/webp">
+        <img alt="lotus" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image23.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video27.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video27.webm" type="video/webm">
+      <source data-src="assets/media/video27.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -866,15 +555,145 @@
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video13.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video13.webm" type="video/webm">
-      <source data-src="assets/media/video13.mp4" type="video/mp4">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video75.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video75.webm" type="video/webm">
+      <source data-src="assets/media/video75.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video3.jpg" preload="none" width="608">
-      <source data-src="assets/media/video3.webm" type="video/webm">
-      <source data-src="assets/media/video3.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image65-1080.avif 1080w, assets/images/image65-480.avif 480w, assets/images/image65-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image65-1080.webp 1080w, assets/images/image65-480.webp 480w, assets/images/image65-800.webp 800w" type="image/webp">
+        <img alt="lostless-live-performance-wall" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image65.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video34.jpg" preload="none" width="608">
+      <source data-src="assets/media/video34.webm" type="video/webm">
+      <source data-src="assets/media/video34.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video6.jpg" preload="none" width="608">
+      <source data-src="assets/media/video6.webm" type="video/webm">
+      <source data-src="assets/media/video6.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video1.jpg" preload="none" width="608">
+      <source data-src="assets/media/video1.webm" type="video/webm">
+      <source data-src="assets/media/video1.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video60.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video60.webm" type="video/webm">
+      <source data-src="assets/media/video60.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image36-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image36-480.webp 480w" type="image/webp">
+        <img alt="squares" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image36.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image48-1080.avif 576w, assets/images/image48-800.avif 576w, assets/images/image48-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image48-1080.webp 576w, assets/images/image48-800.webp 576w, assets/images/image48-480.webp 480w" type="image/webp">
+        <img alt="arctic-flux" decoding="async" height="1024" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image48.webp" width="576">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image66-1080.avif 1080w, assets/images/image66-480.avif 480w, assets/images/image66-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image66-1080.webp 1080w, assets/images/image66-480.webp 480w, assets/images/image66-800.webp 800w" type="image/webp">
+        <img alt="floral-portrait" decoding="async" height="1920" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image66.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video11.jpg" preload="none" width="608">
+      <source data-src="assets/media/video11.webm" type="video/webm">
+      <source data-src="assets/media/video11.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="612" loop muted playsinline poster="assets/media/video71.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video71.webm" type="video/webm">
+      <source data-src="assets/media/video71.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image27-1080.avif 1080w, assets/images/image27-480.avif 480w, assets/images/image27-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image27-1080.webp 1080w, assets/images/image27-480.webp 480w, assets/images/image27-800.webp 800w" type="image/webp">
+        <img alt="liminal-space" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image27.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image3-480.avif 480w, assets/images/image3-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image3-480.webp 480w, assets/images/image3-800.webp 800w" type="image/webp">
+        <img alt="livemusic" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image3.webp" width="914">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video25.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video25.webm" type="video/webm">
+      <source data-src="assets/media/video25.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image59-1080.avif 1080w, assets/images/image59-800.avif 800w, assets/images/image59-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image59-1080.webp 1080w, assets/images/image59-800.webp 800w, assets/images/image59-480.webp 480w" type="image/webp">
+        <img alt="quantum-feather" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image59.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video21.jpg" preload="none" width="610">
+      <source data-src="assets/media/video21.webm" type="video/webm">
+      <source data-src="assets/media/video21.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image43-1080.avif 1080w, assets/images/image43-800.avif 800w, assets/images/image43-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image43-1080.webp 1080w, assets/images/image43-800.webp 800w, assets/images/image43-480.webp 480w" type="image/webp">
+        <img alt="tunnel-flare" decoding="async" height="1928" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image43.webp" width="1088">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video28.jpg" preload="none" width="608">
+      <source data-src="assets/media/video28.webm" type="video/webm">
+      <source data-src="assets/media/video28.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image5-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image5-480.webp 480w" type="image/webp">
+        <img alt="installation" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image5.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video22.jpg" preload="none" width="810">
+      <source data-src="assets/media/video22.webm" type="video/webm">
+      <source data-src="assets/media/video22.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image57-1080.avif 1080w, assets/images/image57-800.avif 800w, assets/images/image57-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image57-1080.webp 1080w, assets/images/image57-800.webp 800w, assets/images/image57-480.webp 480w" type="image/webp">
+        <img alt="spiral-halo" decoding="async" height="720" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image57.webp" width="1280">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video40.jpg" preload="none" width="608">
+      <source data-src="assets/media/video40.webm" type="video/webm">
+      <source data-src="assets/media/video40.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -886,28 +705,153 @@
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image71-1080.avif 1080w, assets/images/image71-480.avif 480w, assets/images/image71-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image71-1080.webp 1080w, assets/images/image71-480.webp 480w, assets/images/image71-800.webp 800w" type="image/webp">
-        <img alt="wizard-of-oz-immersive-stage" decoding="async" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image71.webp" width="1600">
+      <source srcset="assets/images/image25-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image25-480.webp 480w" type="image/webp">
+        <img alt="tiger" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image25.webp" width="608">
      </picture>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image12-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image12-480.webp 480w" type="image/webp">
-        <img alt="surreal" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image12.webp" width="609">
+      <source srcset="assets/images/image58-1080.avif 1080w, assets/images/image58-800.avif 800w, assets/images/image58-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image58-1080.webp 1080w, assets/images/image58-800.webp 800w, assets/images/image58-480.webp 480w" type="image/webp">
+        <img alt="ember-cloud" decoding="async" height="1920" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image58.webp" width="1080">
      </picture>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video25.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video25.webm" type="video/webm">
-      <source data-src="assets/media/video25.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image40-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image40-480.webp 480w" type="image/webp">
+        <img alt="tiger-outline" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image40.webp" width="608">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video29.jpg" preload="none" width="810">
+      <source data-src="assets/media/video29.webm" type="video/webm">
+      <source data-src="assets/media/video29.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
-     <video data-lazy="true" height="612" loop muted playsinline poster="assets/media/video71.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video71.webm" type="video/webm">
-      <source data-src="assets/media/video71.mp4" type="video/mp4">
+     <picture>
+      <source srcset="assets/images/image64-1080.avif 1080w, assets/images/image64-480.avif 480w, assets/images/image64-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image64-1080.webp 1080w, assets/images/image64-480.webp 480w, assets/images/image64-800.webp 800w" type="image/webp">
+        <img alt="live-performance-radial" class="lazy-fade" decoding="async" fetchpriority="high" height="900" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image64.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image24-1080.avif 1080w, assets/images/image24-480.avif 480w, assets/images/image24-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image24-1080.webp 1080w, assets/images/image24-480.webp 480w, assets/images/image24-800.webp 800w" type="image/webp">
+        <img alt="slime-installation" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image24.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image2-1080.avif 1080w, assets/images/image2-480.avif 480w, assets/images/image2-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image2-1080.webp 1080w, assets/images/image2-480.webp 480w, assets/images/image2-800.webp 800w" type="image/webp">
+        <img alt="live-performance-warehouse" decoding="async" height="721" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image2.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video58.jpg" preload="none" width="606">
+      <source data-src="assets/media/video58.webm" type="video/webm">
+      <source data-src="assets/media/video58.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="606" loop muted playsinline poster="assets/media/video76.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video76.webm" type="video/webm">
+      <source data-src="assets/media/video76.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image55-1080.avif 1080w, assets/images/image55-800.avif 800w, assets/images/image55-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image55-1080.webp 1080w, assets/images/image55-800.webp 800w, assets/images/image55-480.webp 480w" type="image/webp">
+        <img alt="stellar-storm" decoding="async" height="900" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image55.webp" width="1600">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image63-1080.avif 1024w, assets/images/image63-800.avif 800w, assets/images/image63-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image63-1080.webp 1024w, assets/images/image63-800.webp 800w, assets/images/image63-480.webp 480w" type="image/webp">
+        <img alt="velvet-thunder" decoding="async" height="576" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image63.webp" width="1024">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video17.jpg" preload="none" width="608">
+      <source data-src="assets/media/video17.webm" type="video/webm">
+      <source data-src="assets/media/video17.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image39-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image39-480.webp 480w" type="image/webp">
+        <img alt="snake-green" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image39.webp" width="609">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image6-1080.avif 1080w, assets/images/image6-480.avif 480w, assets/images/image6-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image6-1080.webp 1080w, assets/images/image6-480.webp 480w, assets/images/image6-800.webp 800w" type="image/webp">
+        <img alt="skull-art" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image6.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video66.jpg" preload="none" width="594">
+      <source data-src="assets/media/video66.webm" type="video/webm">
+      <source data-src="assets/media/video66.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video35.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video35.webm" type="video/webm">
+      <source data-src="assets/media/video35.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video12.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video12.webm" type="video/webm">
+      <source data-src="assets/media/video12.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video20.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video20.webm" type="video/webm">
+      <source data-src="assets/media/video20.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image49-1080.avif 704w, assets/images/image49-800.avif 704w, assets/images/image49-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image49-1080.webp 704w, assets/images/image49-800.webp 704w, assets/images/image49-480.webp 480w" type="image/webp">
+        <img alt="magnetic-pulse" decoding="async" height="1280" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image49.webp" width="704">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image32-1080.avif 1080w, assets/images/image32-480.avif 480w, assets/images/image32-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image32-1080.webp 1080w, assets/images/image32-480.webp 480w, assets/images/image32-800.webp 800w" type="image/webp">
+        <img alt="poison" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image32.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image54-1080.avif 1080w, assets/images/image54-800.avif 800w, assets/images/image54-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image54-1080.webp 1080w, assets/images/image54-800.webp 800w, assets/images/image54-480.webp 480w" type="image/webp">
+        <img alt="skyline-glitch" decoding="async" height="704" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image54.webp" width="1280">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video7.jpg" preload="none" width="608">
+      <source data-src="assets/media/video7.webm" type="video/webm">
+      <source data-src="assets/media/video7.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video46.jpg" preload="none" width="606">
+      <source data-src="assets/media/video46.webm" type="video/webm">
+      <source data-src="assets/media/video46.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
@@ -918,36 +862,92 @@
      </picture>
     </div>
     <div class="gallery-item">
-     <picture>
-      <source srcset="assets/images/image25-480.avif 480w" type="image/avif">
-       <source srcset="assets/images/image25-480.webp 480w" type="image/webp">
-        <img alt="tiger" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image25.webp" width="608">
-     </picture>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="610" loop muted playsinline poster="assets/media/video27.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video27.webm" type="video/webm">
-      <source data-src="assets/media/video27.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video1.jpg" preload="none" width="608">
-      <source data-src="assets/media/video1.webm" type="video/webm">
-      <source data-src="assets/media/video1.mp4" type="video/mp4">
-     </video>
-    </div>
-    <div class="gallery-item">
-     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video9.jpg" preload="none" width="1080">
-      <source data-src="assets/media/video9.webm" type="video/webm">
-      <source data-src="assets/media/video9.mp4" type="video/mp4">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video5.jpg" preload="none" width="612">
+      <source data-src="assets/media/video5.webm" type="video/webm">
+      <source data-src="assets/media/video5.mp4" type="video/mp4">
      </video>
     </div>
     <div class="gallery-item">
      <picture>
-      <source srcset="assets/images/image27-1080.avif 1080w, assets/images/image27-480.avif 480w, assets/images/image27-800.avif 800w" type="image/avif">
-       <source srcset="assets/images/image27-1080.webp 1080w, assets/images/image27-480.webp 480w, assets/images/image27-800.webp 800w" type="image/webp">
-        <img alt="liminal-space" decoding="async" height="608" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image27.webp" width="1080">
+      <source srcset="assets/images/image44-1080.avif 1080w, assets/images/image44-800.avif 800w, assets/images/image44-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image44-1080.webp 1080w, assets/images/image44-800.webp 800w, assets/images/image44-480.webp 480w" type="image/webp">
+        <img alt="nebula-veil" decoding="async" height="902" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image44.webp" width="1600">
      </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video18.jpg" preload="none" width="608">
+      <source data-src="assets/media/video18.webm" type="video/webm">
+      <source data-src="assets/media/video18.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video23.jpg" preload="none" width="608">
+      <source data-src="assets/media/video23.webm" type="video/webm">
+      <source data-src="assets/media/video23.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video3.jpg" preload="none" width="608">
+      <source data-src="assets/media/video3.webm" type="video/webm">
+      <source data-src="assets/media/video3.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video56.jpg" preload="none" width="606">
+      <source data-src="assets/media/video56.webm" type="video/webm">
+      <source data-src="assets/media/video56.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image69-1080.avif 1080w, assets/images/image69-480.avif 480w, assets/images/image69-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image69-1080.webp 1080w, assets/images/image69-480.webp 480w, assets/images/image69-800.webp 800w" type="image/webp">
+        <img alt="porcelain-crown-figure" decoding="async" height="1600" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image69.webp" width="900">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video24.jpg" preload="none" width="608">
+      <source data-src="assets/media/video24.webm" type="video/webm">
+      <source data-src="assets/media/video24.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image38-480.avif 480w" type="image/avif">
+       <source srcset="assets/images/image38-480.webp 480w" type="image/webp">
+        <img alt="ghost" decoding="async" height="1080" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image38.webp" width="606">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video38.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video38.webm" type="video/webm">
+      <source data-src="assets/media/video38.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="608" loop muted playsinline poster="assets/media/video13.jpg" preload="none" width="1080">
+      <source data-src="assets/media/video13.webm" type="video/webm">
+      <source data-src="assets/media/video13.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video4.jpg" preload="none" width="608">
+      <source data-src="assets/media/video4.webm" type="video/webm">
+      <source data-src="assets/media/video4.mp4" type="video/mp4">
+     </video>
+    </div>
+    <div class="gallery-item">
+     <picture>
+      <source srcset="assets/images/image16-1080.avif 1080w, assets/images/image16-480.avif 480w, assets/images/image16-800.avif 800w" type="image/avif">
+       <source srcset="assets/images/image16-1080.webp 1080w, assets/images/image16-480.webp 480w, assets/images/image16-800.webp 800w" type="image/webp">
+        <img alt="jellyfish-clouds" decoding="async" height="609" loading="lazy" sizes="(min-width:1200px) 33vw, (min-width:768px) 50vw, 100vw" src="/assets/images/image16.webp" width="1080">
+     </picture>
+    </div>
+    <div class="gallery-item">
+     <video data-lazy="true" height="1080" loop muted playsinline poster="assets/media/video73.jpg" preload="none" width="612">
+      <source data-src="assets/media/video73.webm" type="video/webm">
+      <source data-src="assets/media/video73.mp4" type="video/mp4">
+     </video>
     </div>
   </section>
  </main>


### PR DESCRIPTION
This publishes the latest static homepage masonry reorders from `codex/reshuffle-homepage-masonry-20260606` so the live site actually changes.

Included:
- latest homepage masonry reshuffle state from `index.html`
- no unrelated repo cleanup or conflict-file handling